### PR TITLE
fix: collectionSelectEl declared as | undefined to satisfy tsc

### DIFF
--- a/src/settings.ts
+++ b/src/settings.ts
@@ -205,7 +205,7 @@ export class QmdSettingTab extends PluginSettingTab {
 
     // ── Default collection (dropdown) ────────────────────────
     const collectionNames = loadCollectionNames();
-    let collectionSelectEl: HTMLSelectElement;
+    let collectionSelectEl: HTMLSelectElement | undefined;
     new Setting(containerEl)
       .setName('Default collection')
       .setDesc('Pre-selected collection in the search modal. "All" searches every collection.')


### PR DESCRIPTION
## Summary

- `collectionSelectEl` was declared as `HTMLSelectElement` but assigned inside an `addDropdown` callback
- TypeScript correctly flags this as TS2454 (used before assigned)
- The async IIFE that follows already uses optional chaining (`?.isConnected`) — widening the type to `HTMLSelectElement | undefined` is the correct fix, no runtime behavior change

## Test plan

- [x] `npx tsc --noEmit` passes clean (zero errors)
- [x] `npm run build` succeeds
- [ ] Default collection dropdown still populates and persists correctly in settings

🤖 Generated with [Claude Code](https://claude.com/claude-code)