### PR TITLE
fix: ship workflow opens a PR for version bump (main is PR-protected)

### DIFF
--- a/.github/workflows/ship.yml
+++ b/.github/workflows/ship.yml
@@ -16,6 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      pull-requests: write
 
     steps:
       - uses: actions/checkout@v4
@@ -66,15 +67,32 @@ jobs:
       - run: npm run build
 
       # ── Commit & tag ───────────────────────────────────────────────────────
+      # main is PR-protected, so the version bump goes through a PR that the
+      # workflow opens and immediately merges (0 required approvals).
       - name: Commit and tag
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          VERSION="${{ steps.bump.outputs.version }}"
+          BRANCH="chore/release-v${VERSION}"
+
           git config user.name  "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
+          git checkout -b "$BRANCH"
           git add manifest.json versions.json
-          git commit -m "chore: release v${{ steps.bump.outputs.version }}"
-          git tag "v${{ steps.bump.outputs.version }}"
-          git push origin HEAD:main
-          git push origin "v${{ steps.bump.outputs.version }}"
+          git commit -m "chore: release v${VERSION}"
+          git push origin "$BRANCH"
+
+          gh pr create \
+            --title "chore: release v${VERSION}" \
+            --body "Automated version bump — ship workflow." \
+            --base main \
+            --head "$BRANCH"
+          gh pr merge "$BRANCH" --merge --delete-branch
+
+          git fetch origin main
+          git tag "v${VERSION}" origin/main
+          git push origin "v${VERSION}"
 
       # ── Package & publish ──────────────────────────────────────────────────
       - name: Package plugin zip


### PR DESCRIPTION
## Summary

- `main` is now protected by a ruleset requiring changes to go through a PR
- The ship workflow was pushing the version-bump commit directly to `main`, which is now blocked
- GitHub Actions cannot be added as a ruleset bypass actor on personal repos (org-level only)

## What changed

The "Commit and tag" step now:
1. Creates a `chore/release-vX.Y.Z` branch
2. Commits the version bump there and pushes
3. Opens a PR against `main`
4. Immediately merges it (ruleset requires 0 approvals, no status checks)
5. Fetches `origin/main` to get the merge commit, then tags and pushes `vX.Y.Z`

Added `pull-requests: write` to the job's permissions block so `gh pr create/merge` work.

## Test plan

- [ ] Dispatch a patch ship — confirm PR opens, merges, release publishes

🤖 Generated with [Claude Code](https://claude.com/claude-code)