### PR TITLE
chore: rename plugin id and references to obsidian-qmd-search

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,5 +1,5 @@
 {
-  "id": "qmd-search",
+  "id": "obsidian-qmd-search",
   "name": "QMD Search",
   "version": "0.4.1",
   "minAppVersion": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "qmd-search",
+  "name": "obsidian-qmd-search",
   "version": "0.1.9",
   "description": "Obsidian plugin for qmd semantic search",
   "main": "main.js",

--- a/src/client/mcp.ts
+++ b/src/client/mcp.ts
@@ -77,7 +77,7 @@ export class McpQmdClient implements QmdClient {
         params: {
           protocolVersion: '2024-11-05',
           capabilities: {},
-          clientInfo: { name: 'qmd-search', version: '0.1.0' },
+          clientInfo: { name: 'obsidian-qmd-search', version: '0.1.0' },
         },
         id: 0,
       });

--- a/src/util/config.ts
+++ b/src/util/config.ts
@@ -36,7 +36,7 @@ export function loadCollectionNames(): string[] {
     return [];
   } catch (err) {
     if ((err as NodeJS.ErrnoException).code !== 'ENOENT') {
-      console.warn('[obsidian-qmd] Could not parse index.yml:', err);
+      console.warn('[obsidian-qmd-search] Could not parse index.yml:', err);
     }
     return [];
   }


### PR DESCRIPTION
Closes #34.

## What changed

- `manifest.json` `id`: `qmd-search` → `obsidian-qmd-search`
- `package.json` `name`: `qmd-search` → `obsidian-qmd-search`
- `src/client/mcp.ts` MCP client name string updated
- `src/util/config.ts` log prefix updated

## Why obsidian-qmd-search

- `achekulaev/obsidian-qmd` is already registered in the Obsidian community plugins list with id `qmd-search` — our old id was a direct collision
- `qmd-semantic-search` is also taken (winboost)
- `obsidian-qmd-search` is free in the registry and matches the new repo name

## Not changed

- CSS classes (`qmd-search-modal`, etc.) — internal presentation, no conflict
- Obsidian command ids (`qmd-search`, `qmd-status`, etc.) — scoped under the plugin id by Obsidian, safe to keep short

## Follow-up

- Reinstall via BRAT with the new URL: `StevenWolfe/obsidian-qmd-search`
- Update vault note path (`projects/obsidian-qmd.md` → `projects/obsidian-qmd-search.md`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)