### PR TITLE
fix: rename zip artifact and deploy path to obsidian-qmd-search

### DIFF
--- a/.github/workflows/ship.yml
+++ b/.github/workflows/ship.yml
@@ -97,9 +97,9 @@ jobs:
       # ── Package & publish ──────────────────────────────────────────────────
       - name: Package plugin zip
         run: |
-          mkdir -p qmd-search
-          cp main.js manifest.json styles.css qmd-search/
-          zip -r qmd-search.zip qmd-search/
+          mkdir -p obsidian-qmd-search
+          cp main.js manifest.json styles.css obsidian-qmd-search/
+          zip -r obsidian-qmd-search.zip obsidian-qmd-search/
 
       - name: Create GitHub release
         uses: softprops/action-gh-release@v3
@@ -107,7 +107,7 @@ jobs:
           tag_name: v${{ steps.bump.outputs.version }}
           name: v${{ steps.bump.outputs.version }}
           files: |
-            qmd-search.zip
+            obsidian-qmd-search.zip
             main.js
             manifest.json
             styles.css

--- a/scripts/deploy.mjs
+++ b/scripts/deploy.mjs
@@ -13,7 +13,7 @@ if (!existsSync('main.js')) {
   process.exit(1);
 }
 
-const dest = join(vaultPath, '.obsidian', 'plugins', 'qmd-search');
+const dest = join(vaultPath, '.obsidian', 'plugins', 'obsidian-qmd-search');
 mkdirSync(dest, { recursive: true });
 
 for (const file of ['main.js', 'manifest.json', 'styles.css']) {


### PR DESCRIPTION
## Summary

- Rename zip artifact `qmd-search.zip` → `obsidian-qmd-search.zip` in `ship.yml`
- Rename internal zip directory `qmd-search/` → `obsidian-qmd-search/` (must match plugin ID for manual installs)
- Fix `deploy.mjs` install path: `.obsidian/plugins/qmd-search` → `.obsidian/plugins/obsidian-qmd-search` — Obsidian loads plugins by matching folder name to `manifest.json` `id`; wrong folder = plugin not found

Missed during the PR #35 rename. The v0.5.0 release zip has the old name; next release will be correct.

## Test plan
- [ ] Ship workflow produces `obsidian-qmd-search.zip` with correct internal directory
- [ ] `npm run deploy` installs to the right plugins folder