### PR TITLE
feat: reindex debounce slider + spiffy README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,95 +1,143 @@
-# QMD Search — Obsidian Plugin
+# QMD Search
 
-Search your [`qmd`](https://github.com/tobi/qmd)-indexed knowledge bases from inside Obsidian — BM25 keyword, vector semantic, and LLM-reranked hybrid search, all running locally.
+[![GitHub release](https://img.shields.io/github/v/release/StevenWolfe/obsidian-qmd-search?label=release)](../../releases/latest)
+[![CI](https://img.shields.io/github/actions/workflow/status/StevenWolfe/obsidian-qmd-search/ci.yml?branch=main&label=CI)](../../actions/workflows/ci.yml)
+[![Obsidian](https://img.shields.io/badge/Obsidian-≥%201.0-7c3aed)](https://obsidian.md)
+[![Desktop only](https://img.shields.io/badge/platform-desktop%20only-18181b)](https://obsidian.md)
+[![License](https://img.shields.io/github/license/StevenWolfe/obsidian-qmd-search)](LICENSE)
 
-> **Desktop only.** Requires the `qmd` CLI and a configured collection.
+**BM25 keyword · vector semantic · LLM-reranked hybrid search — running entirely on your machine.**
 
----
+QMD Search wraps the [`qmd`](https://github.com/tobi/qmd) CLI to bring local hybrid search into Obsidian. No data leaves your machine. Models load on first query and stay warm.
 
-## Prerequisites
-
-1. Install `qmd`:
-   ```bash
-   npm install -g @tobilu/qmd
-   ```
-2. Index at least one collection:
-   ```bash
-   qmd collection add ~/path/to/notes --name my-notes
-   qmd embed
-   ```
-   Or let the plugin walk you through it — see [Onboarding](#onboarding) below.
+> **Desktop only.** Requires the `qmd` CLI and at least one indexed collection.
 
 ---
 
-## Installation
+## Quick start
 
-### Manual
+```bash
+# 1. Install qmd
+npm install -g @tobilu/qmd
 
-1. Download `main.js`, `manifest.json`, and `styles.css` from the [latest release](../../releases/latest).
-2. Copy them to `<vault>/.obsidian/plugins/obsidian-qmd-search/`.
-3. Settings → Community plugins → enable **QMD Search**.
+# 2. Index your vault
+qmd collection add ~/path/to/vault --name my-vault
+qmd embed
+```
 
-### BRAT (beta testing)
+Then install the plugin (see [Installation](#installation)) and open the command palette → **QMD: Search**.
 
-Install [BRAT](https://obsidian.md/plugins?id=obsidian42-brat), then add this repository URL to track releases directly from GitHub.
+---
+
+## How it works
+
+The status bar item is the front door. The hotkey is the primary path.
+
+```mermaid
+flowchart LR
+  U([User])
+  H["⌘⇧F\nhotkey"]
+  SB["Status bar\n· qmd 1,248"]
+  SM[[Search modal]]
+  SP[(Status popover)]
+  ST[[Settings panel]]
+  OB[[Onboarding]]
+
+  U -->|primary path| H --> SM
+  U -->|at-a-glance| SB
+  SB -->|click idle| SP
+  SB -->|click empty| OB
+  SB -->|click error| ST
+  SP -->|Open settings| ST
+```
 
 ---
 
 ## Status bar
 
-The `qmd` indicator in the status bar shows index health at a glance. The dot changes color and label to reflect the current state:
+![Status bar — five states](docs/status-states.svg)
+
+The `qmd` item in Obsidian's status bar shows index health at a glance. The dot communicates state; the number communicates the most useful value.
 
 | State | Dot | Label | Click |
 |-------|-----|-------|-------|
-| Idle | green | doc count | Open status popover |
-| Empty | yellow | `no index` | Open onboarding (or settings) |
-| Indexing | blue pulse | `indexing N / M` | Open status popover |
-| Error | red | `binary not found` / `error` | Open settings |
-| Transient | green | `N results · Xms` | Re-open search modal |
+| **Idle** | 🟢 green | doc count | Open status popover |
+| **Empty** | 🟡 yellow | `no index` | Open onboarding |
+| **Indexing** | 🟣 blue pulse | `indexing N / M` | Open status popover |
+| **Error** | 🔴 red | `binary not found` | Open settings |
+| **After search** | 🟢 green | `N results · Xms` | Re-open last query |
 
 ### Status popover
 
-Clicking the status bar in **idle** or **indexing** state opens a floating popover with collection stats, doc counts, embedding counts, and last-indexed timestamp. Re-index and Open settings actions are available in the footer. Dismiss with a click outside or `Esc`.
-
----
-
-## Onboarding
-
-On first load (or when no collections are indexed), the plugin shows a 4-step checklist:
-
-1. **Binary detected** — confirms `qmd` is on your PATH or configured path
-2. **Vault registered** — register the current vault as a `qmd` collection
-3. **Build index** — run `qmd update` + `qmd embed` to populate the index
-4. **Bind hotkey** — open Settings → Hotkeys and assign the Search command
-
-Each step auto-completes as soon as the condition is met. Skip sets `onboardingDone` and dismisses permanently.
+Click the status bar in idle or indexing state to open a floating panel showing document counts, collections, embedding coverage, last-indexed timestamp, and index size. Re-index and Open settings are in the footer. Dismiss with a click outside or `Esc`.
 
 ---
 
 ## Search
 
-Open the search modal with the **QMD: Search** command (`Ctrl/Cmd+P` → "QMD: Search"), or assign a hotkey in Settings → Hotkeys.
+![Search modal — anatomy](docs/search-modal-anatomy.svg)
 
-### Modes
+Open search with the **QMD: Search** command or a hotkey assigned in Settings → Hotkeys.
+
+### Search modes
 
 | Mode | How it works |
 |------|-------------|
 | **Keyword** | BM25 full-text — fast, exact-term matching |
-| **Semantic** | Vector similarity — finds conceptually related passages |
+| **Semantic** | Vector similarity — finds conceptually related passages even without exact terms |
 | **Hybrid** | Both combined with LLM reranking — best results, slower on first run while models load |
+
+### Result rows
+
+![Result row — anatomy](docs/result-row.svg)
+
+Each result shows a **rank badge**, title, file path, matched snippet with highlighted terms, and a **score bar** (5-segment, proportional to relevance).
 
 ### Keyboard navigation
 
 | Key | Action |
 |-----|--------|
 | `↑` / `↓` | Move between results |
-| `Enter` | Open result in current pane |
-| `⌘Enter` / `Ctrl+Enter` | Open result in new tab |
+| `↵` | Open in active pane |
+| `⌘↵` / `Ctrl+↵` | Open in new tab |
 | `Esc` | Close modal |
 
-Results show a **score bar** (5-segment, proportional to relevance) and a highlighted snippet. The toolbar shows result count and query latency.
+When no query is entered, the modal shows your **5 most recent queries** for instant replay.
 
-When no query is entered, the modal shows your **recent queries** for quick replay.
+---
+
+## Settings
+
+The settings panel renders differently depending on index state:
+
+- **First run** (no collections) — a setup card with a **Register this vault** button. Runs `qmd collection add <vault> --name <name>` followed by `qmd embed`.
+- **Healthy** — a stats panel (docs · collections · embeddings · last indexed) and a collections table. Each row has a `⋯` menu with Rename, Re-index, and Remove.
+
+### Options
+
+| Setting | Default | Description |
+|---------|---------|-------------|
+| `qmd binary path` | `qmd` | Full path to the `qmd` executable if not on PATH |
+| `Transport mode` | CLI | **CLI** spawns a subprocess per query. **MCP HTTP** keeps a persistent daemon (faster after warm-up). |
+| `MCP daemon port` | `8181` | Port for the MCP HTTP daemon |
+| `Default collection` | *(all)* | Pre-selects a collection in the search modal |
+| `Default search mode` | Hybrid | Mode the modal opens with |
+| `Auto-reindex on save` | off | Re-indexes 30 s after a file is created, modified, or deleted |
+| `Reindex delay` | 30 s | How long to wait after the last change before triggering a reindex (5–120 s) |
+| `Log level` | error | Console verbosity: `off` · `error` · `warn` · `debug` |
+
+---
+
+## Onboarding
+
+On first load (or when no collections exist), a 4-step checklist walks through setup:
+
+1. **Binary detected** — confirms `qmd` is reachable
+2. **Vault registered** — registers the current vault as a collection
+3. **Build index** — runs `qmd update` + `qmd embed`
+4. **Bind hotkey** — opens Settings → Hotkeys
+
+Steps 1 and 2 auto-complete on plugin init. Skip marks the modal as done permanently.
 
 ---
 
@@ -103,47 +151,27 @@ When no query is entered, the modal shows your **recent queries** for quick repl
 
 ---
 
-## Settings
+## Installation
 
-### Health panel
+### Manual
 
-The settings tab renders differently depending on index state:
+1. Download `main.js`, `manifest.json`, and `styles.css` from the [latest release](../../releases/latest).
+2. Copy them to `<vault>/.obsidian/plugins/obsidian-qmd-search/`.
+3. Settings → Community plugins → enable **QMD Search**.
 
-- **First run** — a setup card with a **Register this vault** button that runs `qmd collection add <vault> --name <name>` and `qmd embed`.
-- **Healthy** — a stats panel (docs · collections · embeddings · last indexed) and a collections table. Each collection row has a `⋯` menu with Rename, Re-index, and Remove.
+### BRAT (beta testing)
 
-### Options
-
-| Setting | Default | Description |
-|---------|---------|-------------|
-| `qmd binary path` | `qmd` | Full path to the `qmd` executable if not on PATH |
-| `Transport mode` | CLI | **CLI** spawns a subprocess per query. **MCP HTTP** keeps a persistent daemon (faster after warm-up). |
-| `MCP daemon port` | `8181` | Port for the MCP HTTP daemon |
-| `Default collection` | *(all)* | Pre-selects a collection in the search modal |
-| `Default search mode` | Hybrid | Mode the modal opens with |
-| `Auto-reindex` | off | Re-indexes automatically 30 s after a markdown file is created, modified, or deleted |
-| `Log level` | error | Console verbosity: `off` · `error` · `warn` · `debug` |
-
----
-
-## How it works
-
-The plugin communicates with `qmd` via one of two transports:
-
-- **CLI mode** — spawns `qmd search|vsearch|query --json` per query. No daemon needed. First hybrid query may be slow while GGUF models load.
-- **MCP HTTP mode** — connects to `qmd mcp --http` on `localhost:{port}`. The plugin manages daemon start/stop, reusing an existing process if one is running.
-
-Results are normalised from `qmd`'s `qmd://collection/path` URI format into file paths, then matched against the vault for in-editor navigation.
+Install [BRAT](https://obsidian.md/plugins?id=obsidian42-brat), then add this repository URL to track releases from GitHub.
 
 ---
 
 ## Troubleshooting
 
-**`binary not found` in status bar** — Obsidian's Electron process has a stripped PATH. Set the full binary path in settings (e.g. `/home/you/.npm-global/bin/qmd`). The plugin also probes `~/.nvm/versions/node/*/bin`, `~/.local/bin`, `~/.npm-global/bin`, and `/usr/local/bin` automatically.
+**`binary not found` in status bar** — Obsidian's Electron process runs with a stripped PATH. Set the full binary path in settings (e.g. `/home/you/.npm-global/bin/qmd`). The plugin also probes common install locations automatically: `~/.nvm/versions/node/*/bin`, `~/.local/bin`, `~/.npm-global/bin`, `/usr/local/bin`.
 
 **No results** — Run `qmd status` in a terminal to verify the index is healthy. Run `qmd update` or use the Re-index command if files are stale.
 
-**MCP daemon fails to start** — Switch to CLI mode, or run `qmd mcp --http` in a terminal to see error output.
+**MCP daemon fails to start** — Switch to CLI mode, or run `qmd mcp --http` in a terminal to see the error output directly.
 
 ---
 
@@ -158,9 +186,9 @@ npx tsc --noEmit     # type-check only
 VAULT_PATH=~/path/to/vault npm run deploy
 ```
 
-See [CLAUDE.md](CLAUDE.md) for architecture details.
+See [CLAUDE.md](CLAUDE.md) for architecture notes.
 
-To cut a release: use the **Ship Release** workflow dispatch on GitHub (patch / minor / major). It bumps versions, builds, commits, tags, and publishes automatically.
+To cut a release: use the **Ship Release** workflow dispatch on GitHub (patch / minor / major). It bumps versions, builds, commits, tags, and publishes the GitHub release automatically.
 
 ---
 

--- a/docs/color-tokens.svg
+++ b/docs/color-tokens.svg
@@ -1,0 +1,80 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 880 580" font-family="ui-sans-serif, system-ui, -apple-system, Segoe UI, sans-serif">
+  <rect x="1" y="1" width="878" height="578" rx="10" fill="#fafafa" stroke="#d4d4d8" stroke-width="1"></rect>
+
+  <text x="32" y="40" fill="#18181b" font-size="16" font-weight="600">Color tokens → Obsidian CSS variables</text>
+  <text x="32" y="62" fill="#52525b" font-size="12">The hex values are the mock palette only. Map every shipped color to the Obsidian variable in column 3.</text>
+
+  <text x="32" y="100" fill="#a1a1aa" font-size="10.5" font-weight="600" letter-spacing="0.06em">SWATCH</text>
+  <text x="120" y="100" fill="#a1a1aa" font-size="10.5" font-weight="600" letter-spacing="0.06em">ROLE</text>
+  <text x="360" y="100" fill="#a1a1aa" font-size="10.5" font-weight="600" letter-spacing="0.06em">OBSIDIAN VARIABLE</text>
+  <text x="680" y="100" fill="#a1a1aa" font-size="10.5" font-weight="600" letter-spacing="0.06em">MOCK HEX</text>
+  <line x1="32" y1="108" x2="848" y2="108" stroke="#e4e4e7" stroke-width="1"></line>
+
+  
+  
+
+  <rect x="32" y="120" width="60" height="28" rx="4" fill="#1a1a1d" stroke="#e4e4e7"></rect>
+  <text x="120" y="138" fill="#18181b" font-size="13" font-weight="500">App background</text>
+  <text x="360" y="138" fill="#18181b" font-size="12" font-family="ui-monospace, Menlo, Consolas, monospace">--background-primary</text>
+  <text x="680" y="138" fill="#71717a" font-size="11.5" font-family="ui-monospace, Menlo, Consolas, monospace">#1a1a1d</text>
+  <line x1="32" y1="158" x2="848" y2="158" stroke="#e4e4e7" stroke-width="1"></line>
+
+  <rect x="32" y="162" width="60" height="28" rx="4" fill="#232328"></rect>
+  <text x="120" y="180" fill="#18181b" font-size="13" font-weight="500">Surface / card</text>
+  <text x="360" y="180" fill="#18181b" font-size="12" font-family="ui-monospace, Menlo, Consolas, monospace">--background-secondary</text>
+  <text x="680" y="180" fill="#71717a" font-size="11.5" font-family="ui-monospace, Menlo, Consolas, monospace">#232328</text>
+  <line x1="32" y1="200" x2="848" y2="200" stroke="#e4e4e7" stroke-width="1"></line>
+
+  <rect x="32" y="204" width="60" height="28" rx="4" fill="#1d1d21"></rect>
+  <text x="120" y="222" fill="#18181b" font-size="13" font-weight="500">Input background</text>
+  <text x="360" y="222" fill="#18181b" font-size="12" font-family="ui-monospace, Menlo, Consolas, monospace">--background-modifier-form-field</text>
+  <text x="680" y="222" fill="#71717a" font-size="11.5" font-family="ui-monospace, Menlo, Consolas, monospace">#1d1d21</text>
+  <line x1="32" y1="242" x2="848" y2="242" stroke="#e4e4e7" stroke-width="1"></line>
+
+  <rect x="32" y="246" width="60" height="28" rx="4" fill="#2c2c33"></rect>
+  <text x="120" y="264" fill="#18181b" font-size="13" font-weight="500">Border (soft)</text>
+  <text x="360" y="264" fill="#18181b" font-size="12" font-family="ui-monospace, Menlo, Consolas, monospace">--background-modifier-border</text>
+  <text x="680" y="264" fill="#71717a" font-size="11.5" font-family="ui-monospace, Menlo, Consolas, monospace">#2c2c33</text>
+  <line x1="32" y1="284" x2="848" y2="284" stroke="#e4e4e7" stroke-width="1"></line>
+
+  <rect x="32" y="288" width="60" height="28" rx="4" fill="#e7e7ea" stroke="#d4d4d8"></rect>
+  <text x="120" y="306" fill="#18181b" font-size="13" font-weight="500">Default text</text>
+  <text x="360" y="306" fill="#18181b" font-size="12" font-family="ui-monospace, Menlo, Consolas, monospace">--text-normal</text>
+  <text x="680" y="306" fill="#71717a" font-size="11.5" font-family="ui-monospace, Menlo, Consolas, monospace">#e7e7ea</text>
+  <line x1="32" y1="326" x2="848" y2="326" stroke="#e4e4e7" stroke-width="1"></line>
+
+  <rect x="32" y="330" width="60" height="28" rx="4" fill="#a0a0a8"></rect>
+  <text x="120" y="348" fill="#18181b" font-size="13" font-weight="500">Muted text</text>
+  <text x="360" y="348" fill="#18181b" font-size="12" font-family="ui-monospace, Menlo, Consolas, monospace">--text-muted</text>
+  <text x="680" y="348" fill="#71717a" font-size="11.5" font-family="ui-monospace, Menlo, Consolas, monospace">#a0a0a8</text>
+  <line x1="32" y1="368" x2="848" y2="368" stroke="#e4e4e7" stroke-width="1"></line>
+
+  <rect x="32" y="372" width="60" height="28" rx="4" fill="#6e6e78"></rect>
+  <text x="120" y="390" fill="#18181b" font-size="13" font-weight="500">Faint text</text>
+  <text x="360" y="390" fill="#18181b" font-size="12" font-family="ui-monospace, Menlo, Consolas, monospace">--text-faint</text>
+  <text x="680" y="390" fill="#71717a" font-size="11.5" font-family="ui-monospace, Menlo, Consolas, monospace">#6e6e78</text>
+  <line x1="32" y1="410" x2="848" y2="410" stroke="#e4e4e7" stroke-width="1"></line>
+
+  <rect x="32" y="414" width="60" height="28" rx="4" fill="#a78bfa"></rect>
+  <text x="120" y="432" fill="#18181b" font-size="13" font-weight="500">Accent</text>
+  <text x="360" y="432" fill="#18181b" font-size="12" font-family="ui-monospace, Menlo, Consolas, monospace">--interactive-accent</text>
+  <text x="680" y="432" fill="#71717a" font-size="11.5" font-family="ui-monospace, Menlo, Consolas, monospace">#a78bfa</text>
+  <line x1="32" y1="452" x2="848" y2="452" stroke="#e4e4e7" stroke-width="1"></line>
+
+  <rect x="32" y="456" width="60" height="28" rx="4" fill="#4ade80"></rect>
+  <text x="120" y="474" fill="#18181b" font-size="13" font-weight="500">Success</text>
+  <text x="360" y="474" fill="#18181b" font-size="12" font-family="ui-monospace, Menlo, Consolas, monospace">--text-success</text>
+  <text x="680" y="474" fill="#71717a" font-size="11.5" font-family="ui-monospace, Menlo, Consolas, monospace">#4ade80</text>
+  <line x1="32" y1="494" x2="848" y2="494" stroke="#e4e4e7" stroke-width="1"></line>
+
+  <rect x="32" y="498" width="60" height="28" rx="4" fill="#fbbf24"></rect>
+  <text x="120" y="516" fill="#18181b" font-size="13" font-weight="500">Warning</text>
+  <text x="360" y="516" fill="#18181b" font-size="12" font-family="ui-monospace, Menlo, Consolas, monospace">--text-warning</text>
+  <text x="680" y="516" fill="#71717a" font-size="11.5" font-family="ui-monospace, Menlo, Consolas, monospace">#fbbf24</text>
+  <line x1="32" y1="536" x2="848" y2="536" stroke="#e4e4e7" stroke-width="1"></line>
+
+  <rect x="32" y="540" width="60" height="28" rx="4" fill="#f87171"></rect>
+  <text x="120" y="558" fill="#18181b" font-size="13" font-weight="500">Error</text>
+  <text x="360" y="558" fill="#18181b" font-size="12" font-family="ui-monospace, Menlo, Consolas, monospace">--text-error</text>
+  <text x="680" y="558" fill="#71717a" font-size="11.5" font-family="ui-monospace, Menlo, Consolas, monospace">#f87171</text>
+</svg>

--- a/docs/result-row.svg
+++ b/docs/result-row.svg
@@ -1,0 +1,70 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 880 420" font-family="ui-sans-serif, system-ui, -apple-system, Segoe UI, sans-serif">
+  <rect x="1" y="1" width="878" height="418" rx="10" fill="#fafafa" stroke="#d4d4d8" stroke-width="1"></rect>
+
+  <text x="32" y="40" fill="#18181b" font-size="16" font-weight="600">Result row — anatomy</text>
+  <text x="32" y="62" fill="#52525b" font-size="12">All measurements in CSS pixels at default Obsidian zoom. Map every color to an Obsidian CSS variable, not the hex shown.</text>
+
+  
+  <g transform="translate(80, 180)">
+    <rect x="0" y="0" width="720" height="106" fill="#2a2138" stroke="#4c2c8a" stroke-width="1"></rect>
+
+    
+    <rect x="16" y="14" width="28" height="28" rx="6" fill="#27272a" stroke="#3f3f46"></rect>
+    <text x="30" y="33" fill="#d4d4d8" font-size="11" font-family="ui-monospace, Menlo, Consolas, monospace" font-weight="600" text-anchor="middle">01</text>
+
+    
+    <text x="60" y="29" fill="#e4e4e7" font-size="13.5" font-weight="500">OPNsense Prometheus exporter</text>
+    <text x="60" y="46" fill="#71717a" font-size="11.5" font-family="ui-monospace, Menlo, Consolas, monospace">services/observability/opnsense.qmd</text>
+
+    
+    <text x="60" y="72" fill="#a1a1aa" font-size="12">OPNsense</text>
+    <rect x="124" y="60" width="92" height="15" rx="2" fill="#4c2c8a" opacity="0.5"></rect>
+    <text x="170" y="72" fill="#ddd6fe" font-size="12" text-anchor="middle">os-prometheus</text>
+    <text x="222" y="72" fill="#a1a1aa" font-size="12">plugin on gateway. Scraped by</text>
+    <rect x="404" y="60" width="92" height="15" rx="2" fill="#4c2c8a" opacity="0.5"></rect>
+    <text x="450" y="72" fill="#ddd6fe" font-size="12" text-anchor="middle">Grafana Alloy</text>
+    <text x="504" y="72" fill="#a1a1aa" font-size="12">. Configure</text>
+    
+    <text x="60" y="90" fill="#a1a1aa" font-size="12">alert rules for incoming traffic via the webhook listener…</text>
+
+    
+    <text x="700" y="29" fill="#a1a1aa" font-size="11" font-family="ui-monospace, Menlo, Consolas, monospace" text-anchor="end">92%</text>
+    <g transform="translate(670, 36)">
+      <rect x="0" y="0" width="3" height="8" fill="#a78bfa"></rect>
+      <rect x="6" y="0" width="3" height="8" fill="#a78bfa"></rect>
+      <rect x="12" y="0" width="3" height="8" fill="#a78bfa"></rect>
+      <rect x="18" y="0" width="3" height="8" fill="#a78bfa"></rect>
+      <rect x="24" y="0" width="3" height="8" fill="#3f3f46"></rect>
+    </g>
+    <text x="700" y="62" fill="#71717a" font-size="10.5" font-family="ui-monospace, Menlo, Consolas, monospace" text-anchor="end">05/06/26</text>
+  </g>
+
+  
+  <line x1="110" y1="200" x2="60" y2="120" stroke="#a78bfa" stroke-width="1" fill="none"></line>
+  <text x="60" y="110" fill="#18181b" font-size="11.5" font-weight="500">Rank badge</text>
+  <text x="60" y="124" fill="#71717a" font-size="10.5" font-family="ui-monospace, Menlo, Consolas, monospace">28×28 · radius 6 · mono</text>
+
+  <line x1="180" y1="208" x2="200" y2="120" stroke="#a78bfa" stroke-width="1" fill="none"></line>
+  <text x="200" y="110" fill="#18181b" font-size="11.5" font-weight="500">Title</text>
+  <text x="200" y="124" fill="#71717a" font-size="10.5" font-family="ui-monospace, Menlo, Consolas, monospace">13.5px / 500 · --text-normal</text>
+
+  <line x1="200" y1="226" x2="400" y2="120" stroke="#a78bfa" stroke-width="1" fill="none"></line>
+  <text x="400" y="110" fill="#18181b" font-size="11.5" font-weight="500">Path breadcrumb</text>
+  <text x="400" y="124" fill="#71717a" font-size="10.5" font-family="ui-monospace, Menlo, Consolas, monospace">mono 11.5px · --text-faint</text>
+
+  <line x1="270" y1="252" x2="580" y2="120" stroke="#a78bfa" stroke-width="1" fill="none"></line>
+  <text x="580" y="110" fill="#18181b" font-size="11.5" font-weight="500">Snippet · 2 lines</text>
+  <text x="580" y="124" fill="#71717a" font-size="10.5" font-family="ui-monospace, Menlo, Consolas, monospace">&lt;mark&gt; uses accent @ 28%</text>
+
+  <line x1="765" y1="216" x2="780" y2="120" stroke="#a78bfa" stroke-width="1" fill="none"></line>
+  <text x="800" y="110" fill="#18181b" font-size="11.5" font-weight="500" text-anchor="end">Score</text>
+  <text x="800" y="124" fill="#71717a" font-size="10.5" font-family="ui-monospace, Menlo, Consolas, monospace" text-anchor="end">% + 5-bar indicator</text>
+
+  <line x1="765" y1="240" x2="780" y2="324" stroke="#a78bfa" stroke-width="1" fill="none"></line>
+  <text x="800" y="338" fill="#18181b" font-size="11.5" font-weight="500" text-anchor="end">Last modified</text>
+  <text x="800" y="352" fill="#71717a" font-size="10.5" font-family="ui-monospace, Menlo, Consolas, monospace" text-anchor="end">mono 10.5 · --text-faint</text>
+
+  <line x1="60" y1="270" x2="60" y2="324" stroke="#a78bfa" stroke-width="1" fill="none"></line>
+  <text x="60" y="338" fill="#18181b" font-size="11.5" font-weight="500">Focused row bg</text>
+  <text x="60" y="352" fill="#71717a" font-size="10.5" font-family="ui-monospace, Menlo, Consolas, monospace">--interactive-accent @ 16%</text>
+</svg>

--- a/docs/search-modal-anatomy.svg
+++ b/docs/search-modal-anatomy.svg
@@ -1,0 +1,103 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 880 540" font-family="ui-sans-serif, system-ui, -apple-system, Segoe UI, sans-serif">
+  <rect x="1" y="1" width="878" height="538" rx="10" fill="#fafafa" stroke="#d4d4d8" stroke-width="1"></rect>
+
+  <text x="32" y="40" fill="#18181b" font-size="16" font-weight="600">Search modal — anatomy</text>
+  <text x="32" y="62" fill="#52525b" font-size="12">The modal is the most-used surface. Keep it keyboard-first; mode is meta, content is primary.</text>
+
+  
+  <g transform="translate(220, 90)">
+    <rect x="0" y="0" width="440" height="380" rx="10" fill="#18181b" stroke="#2c2c33" stroke-width="1"></rect>
+
+    
+    <line x1="0" y1="49" x2="440" y2="49" stroke="#2c2c33" stroke-width="1"></line>
+    <circle cx="22" cy="25" r="6" fill="none" stroke="#a1a1aa" stroke-width="1.5"></circle>
+    <line x1="26" y1="29" x2="30" y2="33" stroke="#a1a1aa" stroke-width="1.5" stroke-linecap="round"></line>
+    <text x="42" y="29" fill="#e4e4e7" font-size="14">prometheus alert rules</text>
+    <rect x="225" y="13" width="100" height="22" rx="11" fill="#4c2c8a" opacity="0.5"></rect>
+    <text x="275" y="28" fill="#ddd6fe" font-size="11" text-anchor="middle">intent detected</text>
+    <rect x="395" y="14" width="32" height="22" rx="4" fill="#2c2c33" stroke="#45454e"></rect>
+    <text x="411" y="29" fill="#a1a1aa" font-size="10.5" text-anchor="middle" font-family="ui-monospace, Menlo, Consolas, monospace">esc</text>
+
+    
+    <rect x="1" y="50" width="438" height="40" fill="#232328"></rect>
+    <line x1="0" y1="90" x2="440" y2="90" stroke="#2c2c33" stroke-width="1"></line>
+    
+    <rect x="12" y="58" width="160" height="24" rx="5" fill="#1d1d21" stroke="#2c2c33"></rect>
+    <rect x="116" y="60" width="54" height="20" rx="3" fill="#2a2a30" stroke="#45454e"></rect>
+    <text x="36" y="73" fill="#a1a1aa" font-size="11" text-anchor="middle">Keyword</text>
+    <text x="88" y="73" fill="#a1a1aa" font-size="11" text-anchor="middle">Semantic</text>
+    <text x="143" y="73" fill="#e4e4e7" font-size="11" text-anchor="middle">Hybrid</text>
+    
+    <text x="180" y="74" fill="#71717a" font-size="11">in</text>
+    <rect x="196" y="61" width="106" height="20" rx="10" fill="#1d1d21" stroke="#2c2c33"></rect>
+    <text x="249" y="74" fill="#e4e4e7" font-size="11" text-anchor="middle">obsidian-mind</text>
+    
+    <text x="428" y="74" fill="#71717a" font-size="10.5" text-anchor="end" font-family="ui-monospace, Menlo, Consolas, monospace">12 results · 84 ms</text>
+
+    
+    <rect x="1" y="91" width="438" height="74" fill="#2a2138"></rect>
+    <rect x="16" y="105" width="22" height="22" rx="4" fill="#27272a" stroke="#3f3f46"></rect>
+    <text x="27" y="120" fill="#d4d4d8" font-size="10" text-anchor="middle" font-family="ui-monospace, Menlo, Consolas, monospace">01</text>
+    <text x="48" y="115" fill="#e4e4e7" font-size="12" font-weight="500">OPNsense Prometheus exporter</text>
+    <text x="48" y="130" fill="#71717a" font-size="10" font-family="ui-monospace, Menlo, Consolas, monospace">services/observability/opnsense.qmd</text>
+    <text x="48" y="148" fill="#a1a1aa" font-size="11">os-prometheus plugin running on gateway…</text>
+    <text x="425" y="115" fill="#a1a1aa" font-size="10" text-anchor="end" font-family="ui-monospace, Menlo, Consolas, monospace">92%</text>
+
+    
+    <rect x="1" y="166" width="438" height="68" fill="#18181b"></rect>
+    <line x1="0" y1="165" x2="440" y2="165" stroke="#27272a"></line>
+    <rect x="16" y="180" width="22" height="22" rx="4" fill="#27272a" stroke="#3f3f46"></rect>
+    <text x="27" y="195" fill="#d4d4d8" font-size="10" text-anchor="middle" font-family="ui-monospace, Menlo, Consolas, monospace">02</text>
+    <text x="48" y="190" fill="#e4e4e7" font-size="12" font-weight="500">Grafana Alloy — alerting pipeline</text>
+    <text x="48" y="205" fill="#71717a" font-size="10" font-family="ui-monospace, Menlo, Consolas, monospace">services/observability/alloy.qmd</text>
+    <text x="425" y="190" fill="#a1a1aa" font-size="10" text-anchor="end" font-family="ui-monospace, Menlo, Consolas, monospace">81%</text>
+
+    
+    <rect x="1" y="234" width="438" height="68" fill="#18181b"></rect>
+    <line x1="0" y1="234" x2="440" y2="234" stroke="#27272a"></line>
+    <rect x="16" y="248" width="22" height="22" rx="4" fill="#27272a" stroke="#3f3f46"></rect>
+    <text x="27" y="263" fill="#d4d4d8" font-size="10" text-anchor="middle" font-family="ui-monospace, Menlo, Consolas, monospace">03</text>
+    <text x="48" y="258" fill="#e4e4e7" font-size="12" font-weight="500">Homelab alerting playbook</text>
+    <text x="48" y="273" fill="#71717a" font-size="10" font-family="ui-monospace, Menlo, Consolas, monospace">services/runbooks/alerts.qmd</text>
+    <text x="425" y="258" fill="#a1a1aa" font-size="10" text-anchor="end" font-family="ui-monospace, Menlo, Consolas, monospace">74%</text>
+
+    
+    <rect x="1" y="340" width="438" height="40" fill="#232328"></rect>
+    <line x1="0" y1="340" x2="440" y2="340" stroke="#2c2c33"></line>
+    <text x="16" y="364" fill="#71717a" font-size="10.5" font-family="ui-monospace, Menlo, Consolas, monospace">↑↓ navigate · ↵ open · ⌘↵ new tab · ⌘. filters</text>
+    <text x="425" y="364" fill="#71717a" font-size="10.5" text-anchor="end" font-family="ui-monospace, Menlo, Consolas, monospace">qmd · hybrid</text>
+  </g>
+
+  
+  <line x1="220" y1="115" x2="100" y2="115" stroke="#a78bfa" stroke-width="1" fill="none"></line>
+  <text x="32" y="105" fill="#18181b" font-size="11.5" font-weight="500">Search input</text>
+  <text x="32" y="119" fill="#71717a" font-size="10.5" font-family="ui-monospace, Menlo, Consolas, monospace">15px · debounce 120 ms</text>
+
+  <line x1="510" y1="115" x2="780" y2="115" stroke="#a78bfa" stroke-width="1" fill="none"></line>
+  <text x="848" y="105" fill="#18181b" font-size="11.5" font-weight="500" text-anchor="end">Intent pill (auto)</text>
+  <text x="848" y="119" fill="#71717a" font-size="10.5" font-family="ui-monospace, Menlo, Consolas, monospace" text-anchor="end">click → reveal panel</text>
+
+  <line x1="280" y1="160" x2="100" y2="200" stroke="#a78bfa" stroke-width="1" fill="none"></line>
+  <text x="32" y="190" fill="#18181b" font-size="11.5" font-weight="500">Mode selector</text>
+  <text x="32" y="204" fill="#71717a" font-size="10.5" font-family="ui-monospace, Menlo, Consolas, monospace">compact segmented, not pills</text>
+
+  <line x1="470" y1="160" x2="780" y2="200" stroke="#a78bfa" stroke-width="1" fill="none"></line>
+  <text x="848" y="190" fill="#18181b" font-size="11.5" font-weight="500" text-anchor="end">Collection scope</text>
+  <text x="848" y="204" fill="#71717a" font-size="10.5" font-family="ui-monospace, Menlo, Consolas, monospace" text-anchor="end">chip → picker</text>
+
+  <line x1="220" y1="220" x2="100" y2="290" stroke="#a78bfa" stroke-width="1" fill="none"></line>
+  <text x="32" y="280" fill="#18181b" font-size="11.5" font-weight="500">Focused result</text>
+  <text x="32" y="294" fill="#71717a" font-size="10.5" font-family="ui-monospace, Menlo, Consolas, monospace">--interactive-accent @ 16%</text>
+
+  <line x1="660" y1="200" x2="780" y2="290" stroke="#a78bfa" stroke-width="1" fill="none"></line>
+  <text x="848" y="280" fill="#18181b" font-size="11.5" font-weight="500" text-anchor="end">Per-result score</text>
+  <text x="848" y="294" fill="#71717a" font-size="10.5" font-family="ui-monospace, Menlo, Consolas, monospace" text-anchor="end">% + 5-bar indicator</text>
+
+  <line x1="320" y1="450" x2="100" y2="490" stroke="#a78bfa" stroke-width="1" fill="none"></line>
+  <text x="32" y="480" fill="#18181b" font-size="11.5" font-weight="500">Keyboard hints</text>
+  <text x="32" y="494" fill="#71717a" font-size="10.5" font-family="ui-monospace, Menlo, Consolas, monospace">always visible · power-user signal</text>
+
+  <line x1="630" y1="160" x2="780" y2="450" stroke="#a78bfa" stroke-width="1" fill="none"></line>
+  <text x="848" y="480" fill="#18181b" font-size="11.5" font-weight="500" text-anchor="end">Live counters</text>
+  <text x="848" y="494" fill="#71717a" font-size="10.5" font-family="ui-monospace, Menlo, Consolas, monospace" text-anchor="end">n results · latency</text>
+</svg>

--- a/docs/status-states.svg
+++ b/docs/status-states.svg
@@ -1,0 +1,66 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 880 480" font-family="ui-sans-serif, system-ui, -apple-system, Segoe UI, sans-serif">
+  <rect x="1" y="1" width="878" height="478" rx="10" fill="#fafafa" stroke="#d4d4d8" stroke-width="1"></rect>
+
+  <text x="32" y="40" fill="#18181b" font-size="16" font-weight="600">Status bar — five states</text>
+  <text x="32" y="62" fill="#52525b" font-size="12">Pattern: ⟨dot⟩ qmd ⟨unit⟩. Dot color communicates state, text communicates the most useful number.</text>
+
+  <text x="32" y="100" fill="#a1a1aa" font-size="11" font-weight="600" letter-spacing="0.06em">STATE</text>
+  <text x="220" y="100" fill="#a1a1aa" font-size="11" font-weight="600" letter-spacing="0.06em">RENDERING</text>
+  <text x="600" y="100" fill="#a1a1aa" font-size="11" font-weight="600" letter-spacing="0.06em">CLICK BEHAVIOR</text>
+  <line x1="32" y1="108" x2="848" y2="108" stroke="#e4e4e7" stroke-width="1"></line>
+
+  
+  <text x="32" y="148" fill="#52525b" font-size="12" font-weight="500">Idle / healthy</text>
+  <g transform="translate(220, 130)">
+    <rect x="0" y="0" width="220" height="26" rx="5" fill="#18181b" stroke="#27272a"></rect>
+    <circle cx="16" cy="13" r="7" fill="#22c55e" opacity="0.18"></circle>
+    <circle cx="16" cy="13" r="4" fill="#22c55e"></circle>
+    <text x="30" y="17" fill="#e4e4e7" font-size="11.5">qmd</text>
+    <text x="58" y="17" fill="#a1a1aa" font-size="11" font-family="ui-monospace, Menlo, Consolas, monospace">1,248</text>
+  </g>
+  <text x="600" y="148" fill="#71717a" font-size="11" font-family="ui-monospace, Menlo, Consolas, monospace">opens status popover</text>
+
+  
+  <text x="32" y="218" fill="#52525b" font-size="12" font-weight="500">Empty / needs indexing</text>
+  <g transform="translate(220, 200)">
+    <rect x="0" y="0" width="220" height="26" rx="5" fill="#18181b" stroke="#27272a"></rect>
+    <circle cx="16" cy="13" r="7" fill="#f59e0b" opacity="0.18"></circle>
+    <circle cx="16" cy="13" r="4" fill="#f59e0b"></circle>
+    <text x="30" y="17" fill="#e4e4e7" font-size="11.5">qmd</text>
+    <text x="58" y="17" fill="#a1a1aa" font-size="11" font-family="ui-monospace, Menlo, Consolas, monospace">no index</text>
+  </g>
+  <text x="600" y="218" fill="#71717a" font-size="11" font-family="ui-monospace, Menlo, Consolas, monospace">opens onboarding</text>
+
+  
+  <text x="32" y="288" fill="#52525b" font-size="12" font-weight="500">Indexing</text>
+  <g transform="translate(220, 270)">
+    <rect x="0" y="0" width="220" height="26" rx="5" fill="#18181b" stroke="#27272a"></rect>
+    <circle cx="16" cy="13" r="9" fill="#a78bfa" opacity="0.22"></circle>
+    <circle cx="16" cy="13" r="4" fill="#a78bfa"></circle>
+    <text x="30" y="17" fill="#e4e4e7" font-size="11.5">qmd</text>
+    <text x="58" y="17" fill="#a1a1aa" font-size="11" font-family="ui-monospace, Menlo, Consolas, monospace">indexing 412 / 1,248</text>
+  </g>
+  <text x="600" y="288" fill="#71717a" font-size="11" font-family="ui-monospace, Menlo, Consolas, monospace">popover w/ Cancel</text>
+
+  
+  <text x="32" y="358" fill="#52525b" font-size="12" font-weight="500">Error</text>
+  <g transform="translate(220, 340)">
+    <rect x="0" y="0" width="220" height="26" rx="5" fill="#18181b" stroke="#27272a"></rect>
+    <circle cx="16" cy="13" r="7" fill="#ef4444" opacity="0.22"></circle>
+    <circle cx="16" cy="13" r="4" fill="#ef4444"></circle>
+    <text x="30" y="17" fill="#e4e4e7" font-size="11.5">qmd</text>
+    <text x="58" y="17" fill="#a1a1aa" font-size="11" font-family="ui-monospace, Menlo, Consolas, monospace">binary not found</text>
+  </g>
+  <text x="600" y="358" fill="#71717a" font-size="11" font-family="ui-monospace, Menlo, Consolas, monospace">jumps to failing setting</text>
+
+  
+  <text x="32" y="428" fill="#52525b" font-size="12" font-weight="500">After search (3s)</text>
+  <g transform="translate(220, 410)">
+    <rect x="0" y="0" width="220" height="26" rx="5" fill="#18181b" stroke="#27272a"></rect>
+    <circle cx="16" cy="13" r="7" fill="#22c55e" opacity="0.18"></circle>
+    <circle cx="16" cy="13" r="4" fill="#22c55e"></circle>
+    <text x="30" y="17" fill="#e4e4e7" font-size="11.5">qmd</text>
+    <text x="58" y="17" fill="#a1a1aa" font-size="11" font-family="ui-monospace, Menlo, Consolas, monospace">12 results · 84 ms</text>
+  </g>
+  <text x="600" y="428" fill="#71717a" font-size="11" font-family="ui-monospace, Menlo, Consolas, monospace">re-opens last query</text>
+</svg>

--- a/src/main.ts
+++ b/src/main.ts
@@ -16,7 +16,6 @@ import type { PluginStatus } from './client/types';
 const STATUS_REFRESH_INTERVAL_MS = 5 * 60 * 1000;
 const TRANSIENT_DURATION_MS = 3000;
 const MAX_RECENT_QUERIES = 5;
-const AUTO_REINDEX_DEBOUNCE_MS = 30_000;
 
 export default class QmdSearchPlugin extends Plugin {
   settings!: QmdSearchSettings;
@@ -111,7 +110,7 @@ export default class QmdSearchPlugin extends Plugin {
     this.reindexTimer = window.setTimeout(() => {
       this.reindexTimer = null;
       void this.reindex();
-    }, AUTO_REINDEX_DEBOUNCE_MS);
+    }, this.settings.reindexDebounceSeconds * 1000);
   }
 
   async loadSettings(): Promise<void> {

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -29,6 +29,7 @@ export interface QmdSearchSettings {
   recentQueries: string[];
   onboardingDone: boolean;
   autoReindex: boolean;
+  reindexDebounceSeconds: number;
 }
 
 export const DEFAULT_SETTINGS: QmdSearchSettings = {
@@ -45,6 +46,7 @@ export const DEFAULT_SETTINGS: QmdSearchSettings = {
   recentQueries: [],
   onboardingDone: false,
   autoReindex: false,
+  reindexDebounceSeconds: 30,
 };
 
 function runVersion(binary: string): Promise<string> {
@@ -430,6 +432,26 @@ export class QmdSettingTab extends PluginSettingTab {
             await this.plugin.saveSettings(false);
           }),
       );
+
+    const debounceValueEl = section.createEl('span', {
+      text: `${this.plugin.settings.reindexDebounceSeconds}s`,
+      cls: 'qmd-slider-value',
+    });
+    new Setting(section)
+      .setName('Reindex delay')
+      .setDesc('Seconds to wait after the last file change before triggering a reindex.')
+      .setClass('qmd-setting-with-value')
+      .addSlider((slider) =>
+        slider
+          .setLimits(5, 120, 5)
+          .setValue(this.plugin.settings.reindexDebounceSeconds)
+          .onChange(async (value) => {
+            debounceValueEl.setText(`${value}s`);
+            this.plugin.settings.reindexDebounceSeconds = value;
+            await this.plugin.saveSettings(false);
+          }),
+      )
+      .settingEl.append(debounceValueEl);
 
     // qmd binary path
     const versionEl = section.createEl('p', { cls: 'qmd-version-hint' });

--- a/styles.css
+++ b/styles.css
@@ -1003,3 +1003,11 @@
 
 .qmd-version-ok    { color: var(--text-success); }
 .qmd-version-error { color: var(--text-error); }
+
+.qmd-setting-with-value .setting-item-control { gap: 8px; }
+.qmd-slider-value {
+  font-size: 0.85em;
+  min-width: 2.5em;
+  text-align: right;
+  color: var(--text-muted);
+}


### PR DESCRIPTION
## Summary

- **Configurable reindex delay** — adds a 5–120s slider (default 30s) below the auto-reindex toggle. Replaces the hardcoded `AUTO_REINDEX_DEBOUNCE_MS` constant. Completes issue #48.
- **README overhaul** — badges (release, CI, Obsidian, platform, license), Mermaid navigation flow diagram, and three annotated SVG diagrams from the design handoff (status bar states, search modal anatomy, result row anatomy).

## Closes

Closes #48

## Test plan

- [ ] Auto-reindex toggle + delay slider appear together in settings
- [ ] Slider range is 5–120s in 5s steps; value label updates live
- [ ] Reindex fires after the configured delay following a `.md` file change
- [ ] README renders correctly on GitHub: badges, Mermaid diagram, SVG diagrams

🤖 Generated with [Claude Code](https://claude.com/claude-code)