### PR TITLE
feat: Embed action on all maintenance surfaces + command docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,11 +143,18 @@ Steps 1 and 2 auto-complete on plugin init. Skip marks the modal as done permane
 
 ## Commands
 
-| Command | Description |
-|---------|-------------|
-| **QMD: Search** | Open the search modal |
-| **QMD: Re-index collections** | Run `qmd update` to refresh the index |
-| **QMD: Generate embeddings** | Run `qmd embed` to (re)generate vectors |
+| Command | Runs | When to use |
+|---------|------|-------------|
+| **QMD: Search** | *(opens modal)* | Your primary entry point — open this to search |
+| **QMD: Re-index collections** | `qmd update` | After adding, editing, or deleting notes. Updates the text index. Fast. Required for keyword search to see new content. |
+| **QMD: Generate embeddings** | `qmd embed` | After re-indexing, to generate or refresh vector embeddings. Slower (loads the embedding model on first run). Required for semantic and hybrid search to see new content. |
+
+**Typical maintenance workflow:** Re-index → then Embed. Auto-reindex (if enabled) handles Re-index automatically; run Embed manually after bulk changes.
+
+All three commands are available from:
+- **Command palette** (`Ctrl/Cmd+P` → "QMD")
+- **Status bar popover** — Re-index and Embed buttons in the footer
+- **Settings panel** — Re-index and Embed buttons in the health card; Re-index and Generate embeddings in each collection's `⋯` menu
 
 ---
 

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -273,6 +273,14 @@ export class QmdSettingTab extends PluginSettingTab {
     void dot;
     cardHeader.createEl('strong', { text: 'Index healthy' });
 
+    const cardActions = card.createDiv({ cls: 'qmd-health-card-actions' });
+    const reindexCardBtn = cardActions.createEl('button', { cls: 'qmd-health-action-btn', text: '↻ Re-index' });
+    reindexCardBtn.setAttribute('title', 'Run qmd update — refreshes the text index after adding or editing notes. Fast.');
+    reindexCardBtn.addEventListener('click', () => { void this.plugin.reindex(); });
+    const embedCardBtn = cardActions.createEl('button', { cls: 'qmd-health-action-btn', text: '⟳ Embed' });
+    embedCardBtn.setAttribute('title', 'Run qmd embed — generates vector embeddings for semantic/hybrid search. Run after re-indexing.');
+    embedCardBtn.addEventListener('click', () => { void this.plugin.embed(); });
+
     const totalDocs = status.totalDocs ?? status.collections.reduce((n, c) => n + c.docCount, 0);
     const totalVectors = status.totalVectors ?? 0;
     const lastIndexed = status.collections[0]?.lastIndexed;
@@ -340,9 +348,16 @@ export class QmdSettingTab extends PluginSettingTab {
       menuBtn.addEventListener('click', (e: MouseEvent) => {
         const menu = new Menu();
         menu.addItem((item) => {
-          item.setTitle('Re-index').onClick(async () => {
+          item.setTitle('Re-index').setIcon('refresh-cw').onClick(async () => {
             new Notice(`QMD: re-indexing "${col.name}"…`);
             await this.plugin.reindex();
+            this.display();
+          });
+        });
+        menu.addItem((item) => {
+          item.setTitle('Generate embeddings').setIcon('cpu').onClick(async () => {
+            new Notice(`QMD: generating embeddings for "${col.name}"…`);
+            await this.plugin.embed();
             this.display();
           });
         });

--- a/src/ui/StatusPopover.ts
+++ b/src/ui/StatusPopover.ts
@@ -49,11 +49,18 @@ export class StatusPopover {
     // Footer
     const footer = el.createDiv({ cls: 'qmd-popover-footer' });
     const reindexBtn = footer.createEl('button', { cls: 'qmd-popover-btn mod-cta', text: 'Re-index' });
+    reindexBtn.setAttribute('title', 'Update the text index (qmd update) — run after adding or editing notes');
     reindexBtn.addEventListener('click', () => {
       this.close();
       this.plugin.reindex();
     });
-    const settingsBtn = footer.createEl('button', { cls: 'qmd-popover-btn', text: 'Open settings' });
+    const embedBtn = footer.createEl('button', { cls: 'qmd-popover-btn', text: 'Embed' });
+    embedBtn.setAttribute('title', 'Generate vector embeddings (qmd embed) — run after re-indexing to enable semantic search');
+    embedBtn.addEventListener('click', () => {
+      this.close();
+      this.plugin.embed();
+    });
+    const settingsBtn = footer.createEl('button', { cls: 'qmd-popover-btn', text: 'Settings' });
     settingsBtn.addEventListener('click', () => {
       this.close();
       // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/styles.css
+++ b/styles.css
@@ -823,6 +823,29 @@
   font-family: var(--font-monospace);
 }
 
+.qmd-health-card-actions {
+  display: flex;
+  gap: 8px;
+  margin-top: 12px;
+  padding-top: 10px;
+  border-top: 1px solid var(--background-modifier-border);
+}
+
+.qmd-health-action-btn {
+  padding: 4px 12px;
+  font-size: 0.82em;
+  border-radius: var(--radius-s);
+  border: 1px solid var(--background-modifier-border);
+  background: var(--background-primary);
+  color: var(--text-muted);
+  cursor: pointer;
+}
+
+.qmd-health-action-btn:hover {
+  background: var(--background-modifier-hover);
+  color: var(--text-normal);
+}
+
 /* Settings sections */
 .qmd-settings-section {
   margin-bottom: 20px;


### PR DESCRIPTION
## Summary

- **Status popover footer** — adds `Embed` button alongside `Re-index`. Both buttons have descriptive tooltips explaining when to use each.
- **Settings health card** — adds `↻ Re-index` and `⟳ Embed` action buttons in a row below the stats, separated by a border.
- **Collection `⋯` menu** — adds "Generate embeddings" item (with `cpu` icon) between Re-index and Remove.
- **README commands table** — expands to include the underlying CLI command and a "when to use" column; adds a note about the typical Re-index → Embed workflow and lists all surfaces where each command is accessible.

## Why

`qmd embed` was only reachable via the command palette. Users who aren't familiar with the two-step Re-index → Embed workflow had no in-context guidance. Now every maintenance surface that offers Re-index also offers Embed.

## Test plan

- [ ] Status popover: footer shows Re-index · Embed · Settings; tooltips describe each
- [ ] Settings healthy state: health card has action buttons row; both fire correctly
- [ ] Collection ⋯ menu: shows Re-index / Generate embeddings / Remove in order
- [ ] README commands table renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)