### PR TITLE
fix: default collection dropdown out of sync with live status

### DIFF
--- a/src/settings.ts
+++ b/src/settings.ts
@@ -384,11 +384,11 @@ export class QmdSettingTab extends PluginSettingTab {
       });
     }
 
-    this.renderGeneralSettings(container);
+    this.renderGeneralSettings(container, status.collections.map((c) => c.name));
     this.renderAdvancedSection(container, wasAdvancedOpen);
   }
 
-  private renderGeneralSettings(container: HTMLElement): void {
+  private renderGeneralSettings(container: HTMLElement, liveCollectionNames?: string[]): void {
     const section = container.createDiv({ cls: 'qmd-settings-section' });
     section.createEl('div', { cls: 'qmd-section-title', text: 'General' });
 
@@ -406,8 +406,8 @@ export class QmdSettingTab extends PluginSettingTab {
           });
       });
 
-    // Default collection
-    const collectionNames = loadCollectionNames();
+    // Default collection — prefer live names from qmd status; fall back to index.yml
+    const collectionNames = liveCollectionNames ?? loadCollectionNames();
     let collectionSelectEl: HTMLSelectElement | undefined;
     new Setting(section)
       .setName('Default collection')
@@ -425,15 +425,6 @@ export class QmdSettingTab extends PluginSettingTab {
           await this.plugin.saveSettings(false);
         });
       });
-    void (async () => {
-      const names = loadCollectionNames();
-      if (!collectionSelectEl?.isConnected || names.length === 0) return;
-      populateSelect(
-        collectionSelectEl,
-        [{ value: '', label: 'All collections' }, ...names.map((n) => ({ value: n, label: n }))],
-        this.plugin.settings.defaultCollection,
-      );
-    })();
 
     // Auto-reindex
     new Setting(section)


### PR DESCRIPTION
## Problem

The Default Collection dropdown in settings was populated by reading `~/.config/qmd/index.yml` synchronously via `loadCollectionNames()`. The Collections section above it was populated from the live `qmd status` response. When these two sources diverged (stale YAML, different index path, etc.), a collection could appear in the table but not the dropdown.

## Fix

Pass `status.collections.map(c => c.name)` from `renderHealthy()` into `renderGeneralSettings()` as an optional parameter. The dropdown now uses the same live data as the collections table. Falls back to `loadCollectionNames()` (YAML) only in the first-run path where no live status is available.

The redundant async YAML re-fetch inside the dropdown setup is also removed — it was re-reading the same stale source a second time.

## Test plan

- [ ] Collections table and Default collection dropdown show the same collection names
- [ ] Selecting a collection in the dropdown works and persists

🤖 Generated with [Claude Code](https://claude.com/claude-code)