### PR TITLE
fix: onboarding always shows for new vault installs

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -78,16 +78,7 @@ export default class QmdSearchPlugin extends Plugin {
     // Show onboarding after Obsidian has fully loaded
     setTimeout(() => {
       if (!this.settings.onboardingDone) {
-        this.client.status().then((s) => {
-          if (s.collections.length === 0) {
-            new OnboardingModal(this.app, this).open();
-          }
-        }).catch(() => {
-          // binary not found or other error — show onboarding anyway
-          if (!this.settings.onboardingDone) {
-            new OnboardingModal(this.app, this).open();
-          }
-        });
+        new OnboardingModal(this.app, this).open();
       }
     }, 500);
   }


### PR DESCRIPTION
## Problem

Onboarding was gated on `!onboardingDone && collections.length === 0`. In a multi-vault setup where qmd already has collections from another vault, `collections.length > 0` — so the modal never fires for a new vault even though it hasn't been registered.

## Fix

Drop the `collections.length === 0` guard. `onboardingDone` is stored in Obsidian's per-vault plugin data, so it's already the correct and sufficient guard — it's `false` on every fresh install and set to `true` only when the user completes or explicitly skips onboarding. No status call needed at load time.

## Test plan

- [ ] Fresh vault install with other qmd collections already registered globally → onboarding appears
- [ ] Vault where onboarding was previously skipped → onboarding does not appear
- [ ] Fresh vault with no qmd binary → onboarding still appears (previously relied on the catch path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)