### PR TITLE
fix: settings auto-refresh after embed/reindex; pulsing status bar during operations

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -291,6 +291,7 @@ export default class QmdSearchPlugin extends Plugin {
 
   reindex(): Promise<void> {
     const notice = new Notice('QMD: re-indexing collections…', 0);
+    this.showOperationInStatusBar('indexing…');
     const args = this.settings.indexName ? ['--index', this.settings.indexName, 'update'] : ['update'];
     return new Promise((resolve) => {
       execFile(this.resolvedBinaryPath, args, { timeout: 600_000, env: buildEnv() }, (err) => {
@@ -305,6 +306,7 @@ export default class QmdSearchPlugin extends Plugin {
 
   embed(): Promise<void> {
     const notice = new Notice('QMD: generating embeddings…', 0);
+    this.showOperationInStatusBar('embedding…');
     const args = this.settings.indexName ? ['--index', this.settings.indexName, 'embed'] : ['embed'];
     return new Promise((resolve) => {
       execFile(this.resolvedBinaryPath, args, { timeout: 600_000, env: buildEnv() }, (err) => {
@@ -315,6 +317,17 @@ export default class QmdSearchPlugin extends Plugin {
         resolve();
       });
     });
+  }
+
+  /** Immediately render a pulsing in-progress label in the status bar chip. */
+  private showOperationInStatusBar(label: string): void {
+    const el = this.statusBarItem;
+    if (!el) return;
+    el.empty();
+    el.createSpan({ cls: 'qmd-dot qmd-dot--accent qmd-dot--pulse' });
+    el.createSpan({ cls: 'qmd-sb-label', text: 'qmd' });
+    el.createSpan({ cls: 'qmd-sb-value', text: label });
+    el.setAttribute('title', `QMD: ${label}`);
   }
 
   private buildClient(): QmdClient {

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -286,17 +286,37 @@ export class QmdSettingTab extends PluginSettingTab {
     const cardActions = card.createDiv({ cls: 'qmd-health-card-actions' });
     if (isPartial) {
       const embedCta = cardActions.createEl('button', { cls: 'qmd-health-action-btn mod-cta', text: '✨ Generate embeddings' });
-      embedCta.addEventListener('click', () => { void this.plugin.embed(); this.display(); });
+      embedCta.addEventListener('click', async () => {
+        embedCta.disabled = true;
+        embedCta.textContent = '⏳ Embedding…';
+        await this.plugin.embed();
+        if (embedCta.isConnected) this.display();
+      });
       const reindexBtn = cardActions.createEl('button', { cls: 'qmd-health-action-btn', text: '↻ Re-index' });
       reindexBtn.setAttribute('title', 'Refresh the text index (fast). Run before generating embeddings.');
-      reindexBtn.addEventListener('click', () => { void this.plugin.reindex(); });
+      reindexBtn.addEventListener('click', async () => {
+        reindexBtn.disabled = true;
+        reindexBtn.textContent = '⏳ Indexing…';
+        await this.plugin.reindex();
+        if (reindexBtn.isConnected) this.display();
+      });
     } else {
       const reindexCardBtn = cardActions.createEl('button', { cls: 'qmd-health-action-btn', text: '↻ Re-index' });
       reindexCardBtn.setAttribute('title', 'Run qmd update — refreshes the text index after adding or editing notes. Fast.');
-      reindexCardBtn.addEventListener('click', () => { void this.plugin.reindex(); });
+      reindexCardBtn.addEventListener('click', async () => {
+        reindexCardBtn.disabled = true;
+        reindexCardBtn.textContent = '⏳ Indexing…';
+        await this.plugin.reindex();
+        if (reindexCardBtn.isConnected) this.display();
+      });
       const embedCardBtn = cardActions.createEl('button', { cls: 'qmd-health-action-btn', text: '✨ Generate embeddings' });
       embedCardBtn.setAttribute('title', 'Run qmd embed — generates vector embeddings for semantic/hybrid search.');
-      embedCardBtn.addEventListener('click', () => { void this.plugin.embed(); });
+      embedCardBtn.addEventListener('click', async () => {
+        embedCardBtn.disabled = true;
+        embedCardBtn.textContent = '⏳ Embedding…';
+        await this.plugin.embed();
+        if (embedCardBtn.isConnected) this.display();
+      });
     }
 
     // Stats row


### PR DESCRIPTION
## Summary

- **Settings panel auto-refresh**: all embed and reindex button handlers now `await` the operation before calling `this.display()`, so the health card transitions from "Index partial" → "Index healthy" (or shows the updated state) immediately when the operation completes — no manual navigate-away-and-back required
- **In-progress indicator**: `embed()` and `reindex()` in `main.ts` now call `showOperationInStatusBar()` at the start of the operation, rendering a pulsing violet dot with `embedding…` / `indexing…` in the status bar chip for the full duration — important on slow hardware where these operations can take minutes
- Button disables and shows `⏳ Embedding…` / `⏳ Indexing…` for the duration so the user can't double-trigger

## Test plan

- [ ] Click "Generate embeddings" from the partial state health card: button disables and shows ⏳, status bar pulses "embedding…"; when done the card re-renders to "Index healthy" with green dot
- [ ] Click "Re-index" from healthy card: same spinner behavior; card refreshes when done
- [ ] Status bar chip reverts to correct idle state (green/warn) after operation completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)