### PR TITLE
chore: sync package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "obsidian-qmd-search",
-  "version": "0.1.9",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "obsidian-qmd-search",
-      "version": "0.1.9",
+      "version": "0.2.0",
       "dependencies": {
         "js-yaml": "^4.1.0"
       },
@@ -16,7 +16,7 @@
         "builtin-modules": "^5.2.0",
         "electron": "^42.1.0",
         "esbuild": "^0.28.0",
-        "obsidian": "*",
+        "obsidian": "latest",
         "typescript": "^6.0.3"
       }
     },


### PR DESCRIPTION
## Summary

- `package-lock.json` was at v0.1.9 while `package.json` was at v0.2.0 — 3-byte version drift from a version bump that didn't run `npm install`

## Type

- [x] chore — tooling / deps / release

## Test plan

- [ ] `npm install` produces no changes after merging

## Checklist

- [x] `npx tsc --noEmit` passes
- [x] `npm run build` produces a clean `main.js`
- [x] Docs/CI-only change, no runtime impact