### PR TITLE
ci: workflow_call, --auto merge, strip v-prefix from release tags

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     branches: [main, "claude/**"]
   pull_request:
     branches: [main]
+  workflow_call:
 
 jobs:
   typecheck:

--- a/.github/workflows/ship.yml
+++ b/.github/workflows/ship.yml
@@ -93,11 +93,14 @@ jobs:
             --body "Automated version bump — ship workflow." \
             --base main \
             --head "$BRANCH"
-          gh pr merge "$BRANCH" --merge --delete-branch
+          gh pr merge "$BRANCH" --auto --merge --delete-branch
 
+          # Wait for the auto-merge to land before tagging
+          gh pr view "$BRANCH" --json state --jq '.state' || true
+          sleep 15
           git fetch origin main
-          git tag "v${VERSION}" origin/main
-          git push origin "v${VERSION}"
+          git tag "${VERSION}" origin/main
+          git push origin "${VERSION}"
 
       # ── Package & publish ──────────────────────────────────────────────────
       - name: Package plugin zip
@@ -109,8 +112,8 @@ jobs:
       - name: Create GitHub release
         uses: softprops/action-gh-release@v3
         with:
-          tag_name: v${{ steps.bump.outputs.version }}
-          name: v${{ steps.bump.outputs.version }}
+          tag_name: ${{ steps.bump.outputs.version }}
+          name: ${{ steps.bump.outputs.version }}
           files: |
             obsidian-qmd-search.zip
             main.js

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,2 @@
 engine-strict=true
+tag-version-prefix=""


### PR DESCRIPTION
## Summary

- `ci.yml` — add `workflow_call` trigger so `ship.yml` can call it as a reusable workflow (was broken — the `needs: ci` gate silently did nothing)
- `ship.yml` — `gh pr merge --auto` queues merge until required checks pass (was immediate, would fail once branch protection requires checks)
- `ship.yml` + `.npmrc` — release tags are now `0.13.0` not `v0.13.0`; Obsidian's release catalog requires the tag to exactly match `manifest.json`'s `version` with no leading `v` (per obsidian-sample-plugin AGENTS.md)

## Type

- [x] ci — CI/CD changes

## Test plan

- [ ] Trigger Ship Release → verify the `ci` reusable workflow runs and the `ship` job waits for it
- [ ] Verify the created release tag has no `v` prefix after ship completes

## Checklist

- [x] `npx tsc --noEmit` passes
- [x] `npm run build` produces a clean `main.js`
- [x] Docs/CI-only change, no runtime impact