### PR TITLE
fix: search modal layout (BIG BUG — input was at bottom)

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -203,19 +203,25 @@
 }
 
 /* ── Search modal ─────────────────────────────────────────── */
-/* Anchor at 15vh — matches Quick Switcher; never vertically centered (#8) */
+/*
+ * Anchor at 15vh from the top — matches Quick Switcher feel.
+ * align-self + margin-top repositions the modal BOX within modal-container's
+ * centering flex context. Using padding-top on .modal instead creates an empty
+ * void inside an otherwise-centered box, pushing input to the bottom half.
+ */
 .qmd-search-modal.modal {
-  align-items: flex-start;
-  padding-top: 15vh;
+  align-self: flex-start;
+  margin-top: 15vh;
+  padding: 0;
+  width: min(760px, 90vw);
+  min-width: 420px;
+  max-width: min(760px, 90vw);
 }
 
 .qmd-search-modal .modal-content {
   padding: 0;
   display: flex;
   flex-direction: column;
-  width: min(760px, 90vw);
-  min-width: 420px;
-  max-width: min(760px, 90vw);
   overflow: hidden;
 }
 
@@ -344,7 +350,6 @@
 
 /* Results list */
 .qmd-results {
-  flex: 1;
   display: flex;
   flex-direction: column;
   overflow-y: auto;


### PR DESCRIPTION
## Root cause

`padding-top: 15vh` was applied to `.qmd-search-modal.modal`, which is centered in the viewport by Obsidian's `.modal-container` flex context (`align-items: center; justify-content: center`). The padding created a 15vh void **inside** the already-centered modal box — pushing the search bar down into the lower half of the box while the upper half was empty dark background.

## Fix

- **Positioning**: `align-self: flex-start; margin-top: 15vh` on `.modal` — this repositions the modal box itself to 15vh from the top of the viewport, rather than adding empty space inside a centered box.
- **Width**: Moved `width`/`min-width`/`max-width` from `.modal-content` to `.modal` — the outer box must be the right width, not an inner element overflowing it.
- **Padding**: `padding: 0` on `.modal` — removes Obsidian's default 16px internal modal padding; we control spacing per-section inside `modal-content`.
- **Results flex**: Removed `flex: 1` from `.qmd-results` — with no fixed parent height, it was unnecessary.

## Test plan

- [ ] Open Search modal — input should appear at the top of a modal anchored ~15vh from top
- [ ] Run a search — results appear below toolbar, scroll within the modal
- [ ] Modal does not extend below the viewport with many results
- [ ] Empty state (no query) renders naturally without giant empty area

🤖 Generated with [Claude Code](https://claude.com/claude-code)