### PR TITLE
chore: harden ship workflow version handling

### DIFF
--- a/.github/workflows/ship.yml
+++ b/.github/workflows/ship.yml
@@ -36,6 +36,8 @@ jobs:
       - run: npm ci
 
       # ── Bump version ───────────────────────────────────────────────────────
+      # Source of truth: manifest.json. package.json version is pinned to
+      # 0.0.0 and intentionally not bumped — this plugin is not published to npm.
       - name: Bump version numbers
         id: bump
         run: |
@@ -83,6 +85,8 @@ jobs:
 
           git config user.name  "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
+          # Clean up any stale release branch from a prior failed run
+          git push origin --delete "$BRANCH" 2>/dev/null || true
           git checkout -b "$BRANCH"
           git add manifest.json versions.json
           git commit -m "chore: release v${VERSION}"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "obsidian-qmd-search",
-  "version": "0.12.0",
+  "version": "0.0.0",
   "description": "Obsidian plugin for qmd semantic search",
   "main": "main.js",
   "engines": {


### PR DESCRIPTION
## Changes

**`package.json` version → `0.0.0` (frozen)**
The plugin is not published to npm. `manifest.json` is the single source of truth for version. Having `package.json` track a different version created confusion and caused the recent 0.12.2 incident (manifest said 0.12.1, package said 0.12.0, ship read manifest → bumped to 0.12.2, but a stale branch blocked it).

**`ship.yml`: delete stale release branch before push**
If a prior ship run failed after creating the release branch but before merging/cleaning it up, the next dispatch would fail with `[rejected] (fetch first)`. Added `git push origin --delete "$BRANCH" 2>/dev/null || true` before the push step — idempotent, safe, no-ops if the branch doesn't exist.

## Rules going forward

- Version lives in `manifest.json` and `versions.json` only
- `package.json` version stays at `0.0.0` forever — never bump it manually
- To release: dispatch `ship.yml` with `patch` / `minor` / `major`
- To check what version will ship next: `cat manifest.json | grep version`

🤖 Generated with [Claude Code](https://claude.com/claude-code)