### PR TITLE
fix: modal close-button overlap + CI release branch trigger

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,10 @@ name: CI
 
 on:
   push:
-    branches: [main, "claude/**"]
+    # Include chore/release-v* so ship.yml's branch push triggers CI.
+    # GITHUB_TOKEN-created PRs don't fire pull_request events, but the
+    # branch push still fires — this makes auto-merge work without a PAT.
+    branches: [main, "claude/**", "chore/release-v*"]
   pull_request:
     branches: [main]
   workflow_call:

--- a/.github/workflows/ship.yml
+++ b/.github/workflows/ship.yml
@@ -99,9 +99,14 @@ jobs:
             --head "$BRANCH"
           gh pr merge "$BRANCH" --auto --merge --delete-branch
 
-          # Wait for the auto-merge to land before tagging
-          gh pr view "$BRANCH" --json state --jq '.state' || true
-          sleep 15
+          # Wait for the auto-merge to land before tagging (poll, don't sleep blind)
+          for i in $(seq 1 30); do
+            STATE=$(gh pr view "$BRANCH" --json state --jq '.state' 2>/dev/null || echo "UNKNOWN")
+            echo "PR state ($i/30): $STATE"
+            if [ "$STATE" = "MERGED" ]; then break; fi
+            sleep 10
+          done
+
           git fetch origin main
           git tag "${VERSION}" origin/main
           git push origin "${VERSION}"

--- a/styles.css
+++ b/styles.css
@@ -225,12 +225,12 @@
   overflow: hidden;
 }
 
-/* Search bar */
+/* Search bar — extra right padding clears the absolute-positioned modal close button */
 .qmd-search-bar {
   display: flex;
   align-items: center;
   gap: 8px;
-  padding: 12px 14px 10px;
+  padding: 12px 40px 10px 14px;
   border-bottom: 1px solid var(--background-modifier-border);
 }
 
@@ -309,6 +309,7 @@
   padding: 4px 8px;
   font-size: 0.82em;
   font-family: var(--font-interface);
+  max-width: 180px;
 }
 
 .qmd-status-chip {


### PR DESCRIPTION
## CSS fixes

**Search bar padding** — the modal now has `padding: 0` (required for correct layout), but Obsidian's close button is `position: absolute; top: 8px; right: 8px`. Without extra padding, the × sits directly over the right edge of the search input. Added `padding-right: 40px` to `.qmd-search-bar` to clear it.

**Collection select width** — `.qmd-collection-select` had no `max-width`, so it stretched to fill all remaining toolbar space (the status chip's `margin-left: auto` meant nothing to its left grew, so the select expanded to fill). Capped at `max-width: 180px`.

## CI/CD fix

**Root cause**: GitHub blocks `GITHUB_TOKEN`-created PRs from triggering other workflow runs (loop-prevention). The ship workflow creates the release PR with `GITHUB_TOKEN`, so the `pull_request` event never fires → CI never runs → required checks never satisfy → auto-merge never fires.

**Fix**: add `chore/release-v*` to CI's `push` trigger. When ship pushes the release branch, the `push` event fires (not blocked), CI runs, status checks pass, and auto-merge completes — no PAT required.

**Also**: replaced the ship workflow's blind `sleep 15` with a polling loop that checks for PR `MERGED` state before tagging, so the tag always lands on the post-merge commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)