### PR TITLE
fix: settings timestamps use timeAgo, partial refresh, 30s tick

### DIFF
--- a/src/settings.ts
+++ b/src/settings.ts
@@ -10,6 +10,7 @@ import { buildEnv } from './util/env';
 import { loadCollectionNames } from './util/config';
 import type { QmdStatus, IndexHealth } from './client/types';
 import { computeIndexHealth } from './client/types';
+import { timeAgo } from './util/time';
 
 export interface QmdSearchSettings {
   qmdBinaryPath: string;
@@ -112,11 +113,18 @@ export class CollectionNameModal extends Modal {
 }
 
 export class QmdSettingTab extends PluginSettingTab {
+  private tickTimer: number | null = null;
+
   constructor(app: App, private readonly plugin: QmdSearchPlugin) {
     super(app, plugin);
   }
 
+  override hide(): void {
+    if (this.tickTimer !== null) { window.clearInterval(this.tickTimer); this.tickTimer = null; }
+  }
+
   display(): void {
+    if (this.tickTimer !== null) { window.clearInterval(this.tickTimer); this.tickTimer = null; }
     const { containerEl } = this;
     const wasAdvancedOpen =
       containerEl.querySelector<HTMLDetailsElement>('.qmd-advanced-section')?.open ?? false;
@@ -164,13 +172,25 @@ export class QmdSettingTab extends PluginSettingTab {
 
     // ── Async content area ────────────────────────────────────
     const contentArea = containerEl.createDiv({ cls: 'qmd-settings-content' });
-    contentArea.createEl('p', { cls: 'qmd-loading', text: 'Loading index status…' });
+    this.loadContent(contentArea, wasAdvancedOpen);
+  }
 
-    // Fetch status and render appropriate layout
+  /** Refresh only the status content — header and form fields are not touched. */
+  private refreshStatusArea(): void {
+    if (this.tickTimer !== null) { window.clearInterval(this.tickTimer); this.tickTimer = null; }
+    const contentArea = this.containerEl.querySelector<HTMLElement>('.qmd-settings-content');
+    if (!contentArea) { this.display(); return; }
+    const wasAdvancedOpen =
+      contentArea.querySelector<HTMLDetailsElement>('.qmd-advanced-section')?.open ?? false;
+    contentArea.empty();
+    this.loadContent(contentArea, wasAdvancedOpen);
+  }
+
+  private loadContent(contentArea: HTMLElement, wasAdvancedOpen: boolean): void {
+    contentArea.createEl('p', { cls: 'qmd-loading', text: 'Loading index status…' });
     this.plugin.client.status().then((status) => {
       if (!contentArea.isConnected) return;
       contentArea.empty();
-
       if (status.collections.length === 0) {
         this.renderFirstRun(contentArea, wasAdvancedOpen);
       } else {
@@ -179,12 +199,28 @@ export class QmdSettingTab extends PluginSettingTab {
         const health = computeIndexHealth(totalDocs, totalVectors);
         this.renderHealthy(contentArea, status, health, wasAdvancedOpen);
       }
+      this.startTimeTick();
     }).catch((err: Error) => {
       log.error('settings status failed:', err.message);
       if (!contentArea.isConnected) return;
       contentArea.empty();
       this.renderFirstRun(contentArea, wasAdvancedOpen, err.message);
     });
+  }
+
+  /** Tick every 30 s — updates [data-last-indexed] spans in-place without a full redraw. */
+  private startTimeTick(): void {
+    if (this.tickTimer !== null) window.clearInterval(this.tickTimer);
+    this.tickTimer = window.setInterval(() => {
+      if (!this.containerEl.isConnected) {
+        window.clearInterval(this.tickTimer!);
+        this.tickTimer = null;
+        return;
+      }
+      this.containerEl.querySelectorAll<HTMLElement>('[data-last-indexed]').forEach((el) => {
+        el.setText(timeAgo(el.dataset.lastIndexed ?? ''));
+      });
+    }, 30_000);
   }
 
   private renderFirstRun(container: HTMLElement, wasAdvancedOpen: boolean, errorMsg?: string): void {
@@ -224,7 +260,7 @@ export class QmdSettingTab extends PluginSettingTab {
         new Notice(`QMD: generating embeddings for "${name}"…`);
         await this.plugin.embed();
         new Notice(`QMD: vault registered as "${name}" ✓`);
-        this.display();
+        this.refreshStatusArea();
       } catch (err) {
         new Notice(`QMD: registration failed — ${(err as Error).message}`);
         if (indexBtn.isConnected) {
@@ -260,10 +296,9 @@ export class QmdSettingTab extends PluginSettingTab {
     } else {
       cardHeader.createEl('strong', { text: 'Index healthy' });
       if (lastIndexed) {
-        cardHeader.createEl('span', {
-          cls: 'qmd-health-meta',
-          text: `Last indexed ${lastIndexed}`,
-        });
+        const timeEl = cardHeader.createEl('span', { cls: 'qmd-health-meta' });
+        timeEl.dataset.lastIndexed = lastIndexed;
+        timeEl.setText(`Last indexed ${timeAgo(lastIndexed)}`);
       }
     }
 
@@ -275,7 +310,7 @@ export class QmdSettingTab extends PluginSettingTab {
         embedCta.disabled = true;
         embedCta.textContent = '⏳ Embedding…';
         await this.plugin.embed();
-        if (embedCta.isConnected) this.display();
+        if (embedCta.isConnected) this.refreshStatusArea();
       });
       const reindexBtn = cardActions.createEl('button', { cls: 'qmd-health-action-btn', text: '↻ Re-index' });
       reindexBtn.setAttribute('title', 'Refresh the text index (fast). Run before generating embeddings.');
@@ -283,7 +318,7 @@ export class QmdSettingTab extends PluginSettingTab {
         reindexBtn.disabled = true;
         reindexBtn.textContent = '⏳ Indexing…';
         await this.plugin.reindex();
-        if (reindexBtn.isConnected) this.display();
+        if (reindexBtn.isConnected) this.refreshStatusArea();
       });
     } else {
       const reindexCardBtn = cardActions.createEl('button', { cls: 'qmd-health-action-btn', text: '↻ Re-index' });
@@ -292,7 +327,7 @@ export class QmdSettingTab extends PluginSettingTab {
         reindexCardBtn.disabled = true;
         reindexCardBtn.textContent = '⏳ Indexing…';
         await this.plugin.reindex();
-        if (reindexCardBtn.isConnected) this.display();
+        if (reindexCardBtn.isConnected) this.refreshStatusArea();
       });
       const embedCardBtn = cardActions.createEl('button', { cls: 'qmd-health-action-btn', text: '✨ Generate embeddings' });
       embedCardBtn.setAttribute('title', 'Run qmd embed — generates vector embeddings for semantic/hybrid search.');
@@ -300,7 +335,7 @@ export class QmdSettingTab extends PluginSettingTab {
         embedCardBtn.disabled = true;
         embedCardBtn.textContent = '⏳ Embedding…';
         await this.plugin.embed();
-        if (embedCardBtn.isConnected) this.display();
+        if (embedCardBtn.isConnected) this.refreshStatusArea();
       });
     }
 
@@ -344,7 +379,7 @@ export class QmdSettingTab extends PluginSettingTab {
           );
         });
         new Notice(`QMD: "${name}" registered ✓`);
-        this.display();
+        this.refreshStatusArea();
       } catch (err) {
         new Notice(`QMD: failed — ${(err as Error).message}`);
       }
@@ -357,7 +392,9 @@ export class QmdSettingTab extends PluginSettingTab {
       row.createEl('span', { cls: 'qmd-col-name', text: col.name });
       row.createEl('span', { cls: 'qmd-col-docs qmd-muted', text: `${col.docCount.toLocaleString()} docs` });
       if (col.lastIndexed) {
-        row.createEl('span', { cls: 'qmd-col-time qmd-muted', text: col.lastIndexed });
+        const colTimeEl = row.createEl('span', { cls: 'qmd-col-time qmd-muted' });
+        colTimeEl.dataset.lastIndexed = col.lastIndexed;
+        colTimeEl.setText(timeAgo(col.lastIndexed));
       }
       const menuBtn = row.createEl('button', { cls: 'qmd-col-menu', text: '⋯' });
       menuBtn.addEventListener('click', (e: MouseEvent) => {
@@ -366,14 +403,14 @@ export class QmdSettingTab extends PluginSettingTab {
           item.setTitle('Re-index').setIcon('refresh-cw').onClick(async () => {
             new Notice(`QMD: re-indexing "${col.name}"…`);
             await this.plugin.reindex();
-            this.display();
+            this.refreshStatusArea();
           });
         });
         menu.addItem((item) => {
           item.setTitle('Generate embeddings').setIcon('cpu').onClick(async () => {
             new Notice(`QMD: generating embeddings for "${col.name}"…`);
             await this.plugin.embed();
-            this.display();
+            this.refreshStatusArea();
           });
         });
         menu.addSeparator();
@@ -390,7 +427,7 @@ export class QmdSettingTab extends PluginSettingTab {
                 );
               });
               new Notice(`QMD: removed "${col.name}" ✓`);
-              this.display();
+              this.refreshStatusArea();
             } catch (err) {
               new Notice(`QMD: remove failed — ${(err as Error).message}`);
             }
@@ -570,7 +607,7 @@ export class QmdSettingTab extends PluginSettingTab {
           .onChange(async (value) => {
             this.plugin.settings.transportMode = value as 'cli' | 'mcp-http';
             await this.plugin.saveSettings();
-            this.display();
+            this.refreshStatusArea();
           });
       });
 

--- a/src/ui/StatusPopover.ts
+++ b/src/ui/StatusPopover.ts
@@ -1,17 +1,6 @@
 import type QmdSearchPlugin from '../main';
 import type { QmdStatus } from '../client/types';
-
-function timeAgo(dateStr: string): string {
-  const d = new Date(dateStr);
-  if (isNaN(d.getTime())) return dateStr;
-  const diffMs = Date.now() - d.getTime();
-  const diffMin = Math.floor(diffMs / 60000);
-  if (diffMin < 1) return 'just now';
-  if (diffMin < 60) return `${diffMin} min ago`;
-  const diffHr = Math.floor(diffMin / 60);
-  if (diffHr < 24) return `${diffHr} hr ago`;
-  return `${Math.floor(diffHr / 24)} days ago`;
-}
+import { timeAgo } from '../util/time';
 
 export class StatusPopover {
   private el: HTMLElement | null = null;

--- a/src/util/time.ts
+++ b/src/util/time.ts
@@ -1,0 +1,11 @@
+export function timeAgo(dateStr: string): string {
+  const d = new Date(dateStr);
+  if (isNaN(d.getTime())) return dateStr;
+  const diffMs = Date.now() - d.getTime();
+  const diffMin = Math.floor(diffMs / 60000);
+  if (diffMin < 1) return 'just now';
+  if (diffMin < 60) return `${diffMin} min ago`;
+  const diffHr = Math.floor(diffMin / 60);
+  if (diffHr < 24) return `${diffHr} hr ago`;
+  return `${Math.floor(diffHr / 24)} days ago`;
+}


### PR DESCRIPTION
Closes #86.

## What changed

### `src/util/time.ts` (new)
Extracted `timeAgo()` into a shared util. `StatusPopover` imported its own private copy; now both use the same one.

### Settings: `timeAgo()` for Last indexed
`settings.ts` was displaying `lastIndexed` as a raw string (`Last indexed 2026-05-19T18:47:38Z`). Now passes through `timeAgo()` → `Last indexed just now` / `Last indexed 3 min ago`.

Both the health card header and each collection row are fixed. Elements tagged with `data-last-indexed` so the tick can update them without refetching.

### `refreshStatusArea()` — no full DOM rewrite on reindex/embed
Previously every button callback called `this.display()` which nuked the entire settings panel (header, binary pill, all form fields) and flashed "Loading index status…" during the refetch.

`refreshStatusArea()` empties only the `qmd-settings-content` div and repopulates it. Header and form fields stay put.

| Call site | Before | After |
|-----------|--------|-------|
| 9× reindex/embed/add/remove buttons | `this.display()` | `this.refreshStatusArea()` |
| Binary path save | `this.display()` | `this.display()` (still needs header pill refresh) |

### 30s tick timer
`startTimeTick()` runs a `setInterval` every 30 s that walks `[data-last-indexed]` elements and calls `setText(timeAgo(...))` in place — no status fetch, no DOM rebuild. Self-cleans on `hide()` or when `containerEl` disconnects.

## Test plan
- [ ] Open settings — "Last indexed" shows relative time (`just now`, `3 min ago`), not raw timestamp
- [ ] Run re-index — status area refreshes, form fields (transport mode, binary path, etc.) do not flicker
- [ ] Wait 1 min after re-index — "Last indexed" updates from `just now` → `1 min ago` without any interaction
- [ ] Change binary path — full page redraw still happens (binary pill must refresh)
- [ ] Close and reopen settings tab — tick timer restarts cleanly, no stale intervals

🤖 Generated with [Claude Code](https://claude.com/claude-code)