### PR TITLE
fix: point Docs link in settings to GitHub Pages site

### DIFF
--- a/src/settings.ts
+++ b/src/settings.ts
@@ -138,7 +138,7 @@ export class QmdSettingTab extends PluginSettingTab {
     const docsLink = headerMeta.createEl('a', { cls: 'qmd-docs-link', text: 'Docs ↗' });
     docsLink.addEventListener('click', (e) => {
       e.preventDefault();
-      window.open('https://github.com/StevenWolfe/obsidian-qmd-search#readme');
+      window.open('https://stevenwolfe.github.io/obsidian-qmd-search/');
     });
     // Plain muted version text — no colored pill (#15)
     headerMeta.createEl('span', {


### PR DESCRIPTION
Updates the 'Docs ↗' link in the settings header to point to the live docs site at https://stevenwolfe.github.io/obsidian-qmd-search/ instead of the README on GitHub.