### PR TITLE
fix: stabilize ship workflow validation

### DIFF
--- a/.github/workflows/ship.yml
+++ b/.github/workflows/ship.yml
@@ -27,21 +27,17 @@ on:
         default: patch
         type: choice
         options: [patch, minor, major]
-  # Disable push trigger to prevent accidental runs from branches,
-  # but allow it on main if absolutely needed (though ship is intended for dispatch).
   push:
     branches: [main]
 
 jobs:
   ci:
     name: CI gate
-    if: github.ref == 'refs/heads/main'
     uses: ./.github/workflows/ci.yml
 
   ship:
     name: Bump, build, and release
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/main'
     needs: [ci]
     permissions:
       contents: write
@@ -51,7 +47,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          token: ${{ secrets.GH_PAT || github.token }}
+          token: ${{ secrets.GH_PAT || secrets.GITHUB_TOKEN }}
 
       - uses: actions/setup-node@v6
         with:
@@ -104,7 +100,7 @@ jobs:
       - name: Commit and open PR
         id: pr
         env:
-          GH_TOKEN: ${{ secrets.GH_PAT || github.token }}
+          GH_TOKEN: ${{ secrets.GH_PAT || secrets.GITHUB_TOKEN }}
         run: |
           VERSION="${{ steps.bump.outputs.version }}"
           BRANCH="chore/release-v${VERSION}"
@@ -134,7 +130,7 @@ jobs:
       - name: Satisfy required status checks
         if: ${{ !secrets.GH_PAT }}
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           SHA="${{ steps.pr.outputs.sha }}"
           REPO="${{ github.repository }}"
@@ -148,7 +144,7 @@ jobs:
 
       - name: Enable auto-merge and wait
         env:
-          GH_TOKEN: ${{ secrets.GH_PAT || github.token }}
+          GH_TOKEN: ${{ secrets.GH_PAT || secrets.GITHUB_TOKEN }}
         run: |
           BRANCH="${{ steps.pr.outputs.branch }}"
           gh pr merge "$BRANCH" --auto --merge --delete-branch
@@ -163,7 +159,7 @@ jobs:
 
       - name: Tag release
         env:
-          GH_TOKEN: ${{ secrets.GH_PAT || github.token }}
+          GH_TOKEN: ${{ secrets.GH_PAT || secrets.GITHUB_TOKEN }}
         run: |
           VERSION="${{ steps.bump.outputs.version }}"
           git fetch origin main
@@ -180,7 +176,7 @@ jobs:
       - name: Create GitHub release
         uses: softprops/action-gh-release@v3
         with:
-          token: ${{ secrets.GH_PAT || github.token }}
+          token: ${{ secrets.GH_PAT || secrets.GITHUB_TOKEN }}
           tag_name: ${{ steps.bump.outputs.version }}
           name: ${{ steps.bump.outputs.version }}
           files: |


### PR DESCRIPTION
Addresses the 'workflow file issue' seen after #105. 

Changes:
- Reverts experimental job-level 'if' conditions that may cause validation errors.
- Restores 'secrets.GITHUB_TOKEN' for better compatibility with some actions.
- Keeps 'push: branches: [main]' to prevent unintended triggers from feature branches.