### PR TITLE
fix: ship workflow if-condition syntax

### DIFF
--- a/.github/workflows/ship.yml
+++ b/.github/workflows/ship.yml
@@ -128,9 +128,10 @@ jobs:
       # can proceed without a PAT (GITHUB_TOKEN has statuses: write).
       # Skip if using GH_PAT, as real CI will be triggered and satisfy rulesets.
       - name: Satisfy required status checks
-        if: ${{ !secrets.GH_PAT }}
+        if: ${{ env.HAS_PAT == 'false' }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HAS_PAT: ${{ secrets.GH_PAT != '' }}
         run: |
           SHA="${{ steps.pr.outputs.sha }}"
           REPO="${{ github.repository }}"


### PR DESCRIPTION
Fixes a validation error where 'secrets' was used directly in an 'if' condition. 

Changes:
- Maps 'secrets.GH_PAT' presence to an environment variable for the 'if' check.
- Ensures the workflow can be successfully dispatched.