### PR TITLE
fix(ci): create empty commit when bump no-op

### DIFF
--- a/.github/workflows/ship.yml
+++ b/.github/workflows/ship.yml
@@ -113,7 +113,8 @@ jobs:
           git add manifest.json versions.json || true
           # Only commit if there are staged changes (avoid failing when nothing changed)
           if git diff --cached --quiet; then
-            echo "No changes to commit"
+            echo "No changes to commit; creating empty commit so PR can be created"
+            git commit --allow-empty -m "chore: release v${VERSION} (no-op placeholder)"
           else
             git commit -m "chore: release v${VERSION}"
           fi


### PR DESCRIPTION
This makes ship.yml create an empty commit when the automated bump produces no changes so the automated PR can be created.