### PR TITLE
chore: add npm audit to CI, label dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,9 +5,14 @@ updates:
     schedule:
       interval: weekly
     open-pull-requests-limit: 5
+    labels:
+      - dependencies
 
   - package-ecosystem: github-actions
     directory: /
     schedule:
       interval: weekly
     open-pull-requests-limit: 5
+    labels:
+      - dependencies
+      - ci-cd

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,18 @@ jobs:
       - run: npm ci
       - run: npm run lint
 
+  audit:
+    name: Audit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: npm
+      - run: npm ci
+      - run: npm audit --audit-level=high --omit=dev
+
   build:
     name: Build
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

- Adds an `audit` job to `ci.yml`: `npm audit --audit-level=high --omit=dev` — blocks PRs if a production dependency has a critical or high CVE. Dev deps omitted (`electron` etc. generate spurious advisories that don't affect the shipped plugin).
- Labels Dependabot PRs with `dependencies` (npm) and `dependencies` + `ci-cd` (Actions) for easier filtering.
- Dependabot was already configured; no schedule or limit changes.

## What was already in place

- `.github/dependabot.yml` existed with weekly npm + Actions scans but no labels.
- GitHub secret scanning should be enabled manually in Settings → Security & analysis (free for public repos, not automatable via PR).

## Follow-on issues

- #172 — gitleaks in CI (block secrets at PR time)
- #173 — pin Action refs to commit SHAs
- #174 — license compliance check

Closes #171