### PR TITLE
fix(lint): resolve eslint-plugin-obsidianmd 0.3.0 errors

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -48,7 +48,7 @@ export default class QmdSearchPlugin extends Plugin {
     this.statusBarItem.addEventListener('click', () => this.handleStatusBarClick());
 
     // Initial status bar population after a short delay (client may be warming up)
-    setTimeout(() => this.refreshStatusBar(), 3000);
+    window.setTimeout(() => this.refreshStatusBar(), 3000);
     this.registerInterval(window.setInterval(() => this.refreshStatusBar(), STATUS_REFRESH_INTERVAL_MS));
 
     // Auto-reindex: watch for markdown file changes and debounce a re-index run
@@ -78,7 +78,7 @@ export default class QmdSearchPlugin extends Plugin {
     this.addSettingTab(new QmdSettingTab(this.app, this));
 
     // Show onboarding after Obsidian has fully loaded
-    setTimeout(() => {
+    window.setTimeout(() => {
       if (!this.settings.onboardingDone) {
         new OnboardingModal(this.app, this).open();
       } else if (this.settings.prewarmOnLaunch && this.settings.transportMode === 'mcp-http') {

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -545,7 +545,7 @@ export class QmdSettingTab extends PluginSettingTab {
         if (e.key === 'Enter') void save();
         else if (e.key === 'Escape') cancel();
       });
-      setTimeout(() => editEl?.focus(), 50);
+      window.setTimeout(() => editEl?.focus(), 50);
     });
 
     // Insert chip row into the setting control area
@@ -764,7 +764,7 @@ export class CollectionNameModal extends Modal {
       if (e.key === 'Enter') submit();
       else if (e.key === 'Escape') cancel();
     });
-    setTimeout(() => { input.focus(); input.select(); }, 50);
+    window.setTimeout(() => { input.focus(); input.select(); }, 50);
   }
 
   onClose(): void {

--- a/src/ui/SearchModal.ts
+++ b/src/ui/SearchModal.ts
@@ -1,6 +1,6 @@
 const path = require('path') as typeof import('path');
 
-import { App, Modal, Notice } from 'obsidian';
+import { App, Modal, Notice, TFile, sanitizeHTMLToDom } from 'obsidian';
 import type { QmdClient } from '../client/base';
 import type { QmdSearchSettings } from '../settings';
 import type { QmdResult, SearchMode } from '../client/types';
@@ -428,7 +428,7 @@ export class SearchModal extends Modal {
       const snippetEl = content.createEl('p', { cls: 'qmd-result-snippet' });
       const hasMarkTags = /<mark>/i.test(result.snippet);
       if (hasMarkTags) {
-        snippetEl.innerHTML = sanitizeSnippet(result.snippet);
+        snippetEl.appendChild(sanitizeHTMLToDom(sanitizeSnippet(result.snippet)));
       } else {
         snippetEl.setText(result.snippet);
       }
@@ -449,8 +449,9 @@ export class SearchModal extends Modal {
     };
     const openNewTab = async () => {
       const leaf = this.app.workspace.getLeaf('tab');
+      const _absFile = this.app.vault.getAbstractFileByPath(result.path);
       const file =
-        this.app.vault.getFileByPath(result.path) ??
+        (_absFile instanceof TFile ? _absFile : null) ??
         this.app.vault.getMarkdownFiles().find(
           (f) => f.path.endsWith('/' + result.path) || f.basename === result.path.replace(/\.md$/, ''),
         ) ??

--- a/src/util/daemon.ts
+++ b/src/util/daemon.ts
@@ -74,8 +74,8 @@ export async function waitForEndpoint(
     if (await tcpReachable(port, signal)) return;
     if (signal.aborted) return;
     await new Promise<void>((r) => {
-      const t = setTimeout(r, intervalMs);
-      signal.addEventListener('abort', () => { clearTimeout(t); r(); }, { once: true });
+      const t = window.setTimeout(r, intervalMs);
+      signal.addEventListener('abort', () => { window.clearTimeout(t); r(); }, { once: true });
     });
   }
 

--- a/src/util/navigate.ts
+++ b/src/util/navigate.ts
@@ -1,4 +1,4 @@
-import { App, MarkdownView, Notice } from 'obsidian';
+import { App, MarkdownView, Notice, TFile } from 'obsidian';
 import type { QmdResult } from '../client/types';
 
 export async function navigateToResult(app: App, result: QmdResult): Promise<void> {
@@ -6,8 +6,9 @@ export async function navigateToResult(app: App, result: QmdResult): Promise<voi
   // Normalise separators and case for Linux (case-sensitive FS) before matching.
   const normalise = (p: string) => p.replace(/\\/g, '/').toLowerCase();
   const pathNorm = normalise(result.path);
+  const _absFile = app.vault.getAbstractFileByPath(result.path);
   const file =
-    app.vault.getFileByPath(result.path) ??
+    (_absFile instanceof TFile ? _absFile : null) ??
     app.vault.getMarkdownFiles().find((f) => {
       const fp = normalise(f.path);
       return fp === pathNorm ||


### PR DESCRIPTION
Unblocks the Dependabot PR #184 (`eslint-plugin-obsidianmd` 0.1.9 → 0.3.0) by fixing the 9 errors the new rule set introduced.

## Changes

**`prefer-window-timers`** (6 occurrences across 3 files) — bare `setTimeout`/`clearTimeout` replaced with `window.setTimeout`/`window.clearTimeout` for popout window compatibility:
- `src/main.ts` — lines 51, 81
- `src/settings.ts` — lines 548, 767
- `src/util/daemon.ts` — lines 77, 78

**`no-unsanitized/property`** (`SearchModal.ts`) — replaced `innerHTML` assignment with Obsidian's `sanitizeHTMLToDom()`. Content was already restricted to `<mark>` tags only by `sanitizeSnippet()`; this adds the DOMPurify layer the rule requires.

**`no-unsupported-api`** (`SearchModal.ts`, `navigate.ts`) — `Vault.getFileByPath()` requires Obsidian v1.5.7 but `minAppVersion` is 1.0.0. Replaced with `getAbstractFileByPath()` + `TFile instanceof` guard — compatible back to 1.0.0 and functionally identical.

## Verification

Ran `eslint-plugin-obsidianmd@0.3.0` locally: **0 errors, 80 warnings** (warnings are pre-existing and separate from this PR).

After this merges, PR #184 should pass CI and can be merged.