### PR TITLE
fix(ci): use GH_PAT for semantic-release to fix 403 on release creation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Release
         run: npx semantic-release
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GH_PAT }}
           GIT_AUTHOR_NAME: github-actions[bot]
           GIT_AUTHOR_EMAIL: github-actions[bot]@users.noreply.github.com
           GIT_COMMITTER_NAME: github-actions[bot]


### PR DESCRIPTION
The Release workflow was failing with `403 Resource not accessible by integration` when `@semantic-release/github` tried to create the GitHub release object.

**Root cause**: `GITHUB_TOKEN` is scoped to the workflow run and has restricted permissions when the repo has an active ruleset with bypass actors. The PAT (`GH_PAT`) already has full `repo` scope and was already being used for the checkout step.

**Fix**: Use `GH_PAT` as the `GITHUB_TOKEN` env var for the semantic-release step, consistent with how it's used for the checkout.

**Symptoms of the bug**: v0.12.12 got a tag and a release commit but no GitHub release — had to create it manually.

After this merges, the next `fix:`/`feat:` push to main will create the full release automatically.