### PR TITLE
feat: local telemetry plumbing (opt-in, #185)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,3 +55,12 @@ jobs:
           cache: npm
       - run: npm ci
       - run: npm run build
+      - name: Upload plugin artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: obsidian-qmd-search
+          path: |
+            main.js
+            manifest.json
+            styles.css
+          retention-days: 7

--- a/src/client/cli.ts
+++ b/src/client/cli.ts
@@ -11,6 +11,7 @@ import type {
 import { normalizeResult } from './types';
 import { log } from '../util/log';
 import { buildEnv } from '../util/env';
+import { timed } from '../util/telemetry';
 
 const MODE_CMD: Record<SearchOptions['mode'], string> = {
   keyword: 'search',
@@ -167,12 +168,14 @@ export class CliQmdClient implements QmdClient {
     if (opts.minScore) args.push('--min-score', String(opts.minScore));
 
     log.debug('search opts:', opts);
-    const raw = await runQmd(this.binary, args);
-    // Output is a bare JSON array, not {results: [...]}
-    const parsed = JSON.parse(raw) as RawQmdResult[] | { results?: RawQmdResult[] };
-    const items = Array.isArray(parsed) ? parsed : (parsed.results ?? []);
-    log.debug('search returned', items.length, 'results');
-    return items.map(normalizeResult);
+    return timed({ command: cmd, transport: 'cli', mode: opts.mode }, async () => {
+      const raw = await runQmd(this.binary, args);
+      // Output is a bare JSON array, not {results: [...]}
+      const parsed = JSON.parse(raw) as RawQmdResult[] | { results?: RawQmdResult[] };
+      const items = Array.isArray(parsed) ? parsed : (parsed.results ?? []);
+      log.debug('search returned', items.length, 'results');
+      return items.map(normalizeResult);
+    }, (results) => results.length);
   }
 
   async get(pathOrDocid: string): Promise<QmdDocument> {

--- a/src/client/mcp.ts
+++ b/src/client/mcp.ts
@@ -1,6 +1,7 @@
 const http = require('http') as typeof import('http');
 
 import { log } from '../util/log';
+import { timed } from '../util/telemetry';
 
 import type { QmdClient } from './base';
 import type {
@@ -180,9 +181,11 @@ export class McpQmdClient implements QmdClient {
     if (opts.candidateLimit) args['candidates'] = opts.candidateLimit;
     if (opts.minScore) args['min_score'] = opts.minScore;
 
-    const result = (await this.rpc('query', args)) as RawQmdResult[] | { results?: RawQmdResult[] } | null;
-    const items = Array.isArray(result) ? result : (result?.results ?? []);
-    return items.map(normalizeResult);
+    return timed({ command: 'query', transport: 'mcp', mode: opts.mode }, async () => {
+      const result = (await this.rpc('query', args)) as RawQmdResult[] | { results?: RawQmdResult[] } | null;
+      const items = Array.isArray(result) ? result : (result?.results ?? []);
+      return items.map(normalizeResult);
+    }, (results) => results.length);
   }
 
   async get(pathOrDocid: string): Promise<QmdDocument> {

--- a/src/main.ts
+++ b/src/main.ts
@@ -12,6 +12,13 @@ import { StatusPopover } from './ui/StatusPopover';
 import { OnboardingModal } from './ui/OnboardingModal';
 import type { PluginStatus } from './client/types';
 import { computeIndexHealth } from './client/types';
+import {
+  setTelemetryEnabled,
+  record,
+  emitVersionSnapshot,
+  maybeEmitIndexSnapshot,
+  emitHardwareSnapshot,
+} from './util/telemetry';
 
 const STATUS_REFRESH_INTERVAL_MS = 5 * 60 * 1000;
 const TRANSIENT_DURATION_MS = 3000;
@@ -40,6 +47,7 @@ export default class QmdSearchPlugin extends Plugin {
     this.resolvedBinaryPath = await initShellContext(this.settings.qmdBinaryPath);
     log.debug('plugin loaded: binary=%s transport=%s', this.resolvedBinaryPath, this.settings.transportMode);
     this.client = this.buildClient();
+    emitVersionSnapshot(this.resolvedBinaryPath, this.manifest.version);
 
     this.statusBarItem = this.addStatusBarItem();
     this.statusBarItem.addClass('qmd-status-bar');
@@ -130,11 +138,13 @@ export default class QmdSearchPlugin extends Plugin {
   async loadSettings(): Promise<void> {
     this.settings = Object.assign({}, DEFAULT_SETTINGS, await this.loadData());
     setLogLevel(this.settings.logLevel);
+    setTelemetryEnabled(this.settings.telemetryEnabled);
   }
 
   async saveSettings(rebuildClient = true): Promise<void> {
     await this.saveData(this.settings);
     setLogLevel(this.settings.logLevel);
+    setTelemetryEnabled(this.settings.telemetryEnabled);
     if (rebuildClient) {
       this.client.dispose().catch(console.error);
       this.resolvedBinaryPath = await initShellContext(this.settings.qmdBinaryPath);
@@ -275,6 +285,9 @@ export default class QmdSearchPlugin extends Plugin {
           health: computeIndexHealth(totalDocs, totalVectors),
         });
 
+        maybeEmitIndexSnapshot(totalDocs, totalVectors, s.collections.length);
+        emitHardwareSnapshot(s.gpuInfo, s.gpuVram, s.gpuDevice);
+
         // Maintenance reminder: if not auto-reindexing and index is older than 24h
         if (!this.settings.autoReindex && lastIndexed) {
           const lastDate = new Date(lastIndexed);
@@ -322,8 +335,10 @@ export default class QmdSearchPlugin extends Plugin {
     const notice = new Notice('QMD: re-indexing collections…', 0);
     this.showOperationInStatusBar('indexing…');
     const args = this.settings.indexName ? ['--index', this.settings.indexName, 'update'] : ['update'];
+    const t0 = Date.now();
     return new Promise((resolve) => {
       execFile(this.resolvedBinaryPath, args, { timeout: 600_000, env: buildEnv() }, (err) => {
+        record({ kind: 'command_timing', command: 'update', transport: 'cli', duration_ms: Date.now() - t0, success: !err });
         notice.hide();
         if (err) new Notice(`QMD: re-index error — ${err.message}`);
         else new Notice('QMD: re-index complete ✓');
@@ -337,8 +352,10 @@ export default class QmdSearchPlugin extends Plugin {
     const notice = new Notice('QMD: generating embeddings…', 0);
     this.showOperationInStatusBar('embedding…');
     const args = this.settings.indexName ? ['--index', this.settings.indexName, 'embed'] : ['embed'];
+    const t0 = Date.now();
     return new Promise((resolve) => {
       execFile(this.resolvedBinaryPath, args, { timeout: 600_000, env: buildEnv() }, (err) => {
+        record({ kind: 'command_timing', command: 'embed', transport: 'cli', duration_ms: Date.now() - t0, success: !err });
         notice.hide();
         if (err) new Notice(`QMD: embed error — ${err.message}`);
         else new Notice('QMD: embeddings complete ✓');

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -9,6 +9,7 @@ import { type LogLevel, setLogLevel, log } from './util/log';
 import { buildEnv } from './util/env';
 import { timeAgo } from './util/time';
 import { computeIndexHealth, type IndexHealth, type QmdStatus, type QmdCollectionStatus } from './client/types';
+import { buildDiagnosticsReport, postReport } from './util/telemetry';
 
 // Fallback if status call fails
 function loadCollectionNames(): string[] {
@@ -493,10 +494,10 @@ export class QmdSettingTab extends PluginSettingTab {
       })
       .settingEl.append(debounceValueEl);
 
-    // Telemetry opt-in
+    // ── Telemetry & diagnostics ───────────────────────────────────────────────
     new Setting(section)
       .setName('Usage analytics')
-      .setDesc('Record timing and index stats locally to ~/.cache/qmd/telemetry.jsonl. Opt-in, stored on your machine only, never uploaded.')
+      .setDesc('Background collection of timing and index stats to ~/.cache/qmd/telemetry.jsonl. Opt-in, stored on your machine only, never uploaded automatically.')
       .addToggle((toggle) =>
         toggle
           .setValue(this.plugin.settings.telemetryEnabled)
@@ -505,6 +506,60 @@ export class QmdSettingTab extends PluginSettingTab {
             await this.plugin.saveSettings(false);
           }),
       );
+
+    // Diagnostics card — always available, not gated by telemetry toggle
+    const diagCard = section.createDiv({ cls: 'qmd-diag-card' });
+    diagCard.createEl('div', { cls: 'qmd-diag-label', text: 'Diagnostics report' });
+    diagCard.createEl('p', {
+      cls: 'qmd-muted',
+      text: 'Snapshot of version, index, hardware, and recent timings. Useful for bug reports.',
+    });
+
+    const diagBtnRow = diagCard.createDiv({ cls: 'qmd-diag-btn-row' });
+
+    const makeSettingsSnap = () => ({
+      transportMode:      this.plugin.settings.transportMode,
+      defaultSearchMode:  this.plugin.settings.defaultSearchMode,
+      noRerank:           this.plugin.settings.noRerank,
+      indexName:          this.plugin.settings.indexName,
+      logLevel:           this.plugin.settings.logLevel,
+      telemetryEnabled:   this.plugin.settings.telemetryEnabled,
+    });
+
+    const copyBtn = diagBtnRow.createEl('button', { cls: 'qmd-diag-btn', text: '📋 Copy' });
+    copyBtn.addEventListener('click', () => {
+      navigator.clipboard.writeText(buildDiagnosticsReport(makeSettingsSnap()))
+        .then(() => new Notice('QMD: diagnostics copied to clipboard ✓'))
+        .catch(() => new Notice('QMD: clipboard write failed'));
+    });
+
+    const shareBtn = diagBtnRow.createEl('button', { cls: 'qmd-diag-btn', text: '📤 Share…' });
+    const shareResult = diagCard.createDiv({ cls: 'qmd-diag-share-result qmd-diag-share-result--hidden' });
+
+    shareBtn.addEventListener('click', async () => {
+      shareBtn.disabled = true;
+      shareBtn.textContent = '⏳ Uploading…';
+      shareResult.addClass('qmd-diag-share-result--hidden');
+      try {
+        const url = await postReport(buildDiagnosticsReport(makeSettingsSnap()));
+        shareResult.empty();
+        shareResult.removeClass('qmd-diag-share-result--hidden');
+        const urlEl = shareResult.createEl('a', { cls: 'qmd-diag-url', href: url, text: url });
+        urlEl.addEventListener('click', (e: MouseEvent) => {
+          e.preventDefault();
+          window.open(url, '_blank');
+        });
+        shareResult.createEl('p', {
+          cls: 'qmd-diag-privacy-warn',
+          text: '⚠ Not private — anyone with this URL can view the contents. Share only with developers.',
+        });
+      } catch (err) {
+        new Notice(`QMD: share failed — ${(err as Error).message}`);
+      } finally {
+        shareBtn.textContent = '📤 Share…';
+        shareBtn.disabled = false;
+      }
+    });
 
     // qmd binary path — read-only chip with Change… button (#6)
     const autoDetected = this.plugin.resolvedBinaryPath !== 'qmd' && this.plugin.settings.qmdBinaryPath === 'qmd';

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -497,7 +497,7 @@ export class QmdSettingTab extends PluginSettingTab {
     // ── Telemetry & diagnostics ───────────────────────────────────────────────
     new Setting(section)
       .setName('Usage analytics')
-      .setDesc('Background collection of timing and index stats to ~/.cache/qmd/telemetry.jsonl. Opt-in, stored on your machine only, never uploaded automatically.')
+      .setDesc('Background collection of timing and index stats to ~/.cache/qmd/telemetry.jsonl. Opt-in, stored on your machine only, never uploaded automatically. For the plugin author\'s personal testing — not a third-party analytics service.')
       .addToggle((toggle) =>
         toggle
           .setValue(this.plugin.settings.telemetryEnabled)

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -32,6 +32,7 @@ export interface QmdSearchSettings {
   reindexDebounceSeconds: number;
   prewarmOnLaunch: boolean;
   searchAhead: boolean;
+  telemetryEnabled: boolean;
 }
 
 export const DEFAULT_SETTINGS: QmdSearchSettings = {
@@ -51,6 +52,7 @@ export const DEFAULT_SETTINGS: QmdSearchSettings = {
   reindexDebounceSeconds: 90,
   prewarmOnLaunch: true,
   searchAhead: true,
+  telemetryEnabled: false,
 };
 
 export class QmdSettingTab extends PluginSettingTab {
@@ -490,6 +492,19 @@ export class QmdSettingTab extends PluginSettingTab {
         slider.sliderEl.title = '1s … 5m';
       })
       .settingEl.append(debounceValueEl);
+
+    // Telemetry opt-in
+    new Setting(section)
+      .setName('Usage analytics')
+      .setDesc('Record timing and index stats locally to ~/.cache/qmd/telemetry.jsonl. Opt-in, stored on your machine only, never uploaded.')
+      .addToggle((toggle) =>
+        toggle
+          .setValue(this.plugin.settings.telemetryEnabled)
+          .onChange(async (value) => {
+            this.plugin.settings.telemetryEnabled = value;
+            await this.plugin.saveSettings(false);
+          }),
+      );
 
     // qmd binary path — read-only chip with Change… button (#6)
     const autoDetected = this.plugin.resolvedBinaryPath !== 'qmd' && this.plugin.settings.qmdBinaryPath === 'qmd';

--- a/src/util/telemetry.ts
+++ b/src/util/telemetry.ts
@@ -1,9 +1,12 @@
 const fs = require('fs') as typeof import('fs');
 const os = require('os') as typeof import('os');
 const path = require('path') as typeof import('path');
+const https = require('https') as typeof import('https');
 const { execFile } = require('child_process') as typeof import('child_process');
 
 import { buildEnv } from './env';
+
+// ── Event schema ────────────────────────────────────────────────────────────
 
 export type TelemetryEvent =
   | { kind: 'command_timing'; command: string; transport: 'cli' | 'mcp'; mode?: string; duration_ms: number; success: boolean; result_count?: number }
@@ -11,15 +14,66 @@ export type TelemetryEvent =
   | { kind: 'index_snapshot'; total_docs: number; total_vectors: number; collection_count: number }
   | { kind: 'hardware_snapshot'; cpu_cores: number; gpu_info?: string; gpu_vram?: string; gpu_device?: string };
 
+type RingEntry = { ts: string } & TelemetryEvent;
+
+// ── Snapshot types (for diagnostics report) ─────────────────────────────────
+
+interface VersionSnap {
+  plugin_version: string;
+  qmd_version: string;
+  node_version: string;
+  electron_version: string;
+  os_platform: string;
+  os_arch: string;
+  cpu_cores: number;
+}
+
+interface HardwareSnap {
+  cpu_cores: number;
+  gpu_info?: string;
+  gpu_vram?: string;
+  gpu_device?: string;
+}
+
+interface IndexSnap {
+  total_docs: number;
+  total_vectors: number;
+  collection_count: number;
+}
+
+// ── Settings snapshot (caller-provided, no circular dep on settings.ts) ──────
+
+export interface DiagnosticsSettingsSnapshot {
+  transportMode: string;
+  defaultSearchMode: string;
+  noRerank: boolean;
+  indexName: string;
+  logLevel: string;
+  telemetryEnabled: boolean;
+}
+
+// ── Module state ─────────────────────────────────────────────────────────────
+
 let _enabled = false;
 let _versionSnapshotEmitted = false;
 let _hardwareSnapshotEmitted = false;
 let _lastIndexSnapshotDate = '';
 
+// Cached for diagnostics report — populated regardless of _enabled
+let _versionSnap: VersionSnap | null = null;
+let _hardwareSnap: HardwareSnap | null = null;
+let _indexSnap: IndexSnap | null = null;
+
+// In-memory ring: always populated (no disk write), used for diagnostics export
+const RING_MAX = 100;
+const _ring: RingEntry[] = [];
+
+// ── Core API ─────────────────────────────────────────────────────────────────
+
 export function setTelemetryEnabled(v: boolean): void {
   _enabled = v;
-  // Reset per-session flags when re-enabled so a fresh session gets fresh snapshots
   if (v) {
+    // Re-enable resets per-session emission flags so fresh snapshots are written
     _versionSnapshotEmitted = false;
     _hardwareSnapshotEmitted = false;
   }
@@ -34,28 +88,33 @@ function telemetryPath(): string {
 }
 
 export function record(event: TelemetryEvent): void {
+  const entry = { ts: new Date().toISOString(), ...event };
+
+  // Ring is always updated (in-memory only, used for diagnostics)
+  if (_ring.length >= RING_MAX) _ring.shift();
+  _ring.push(entry);
+
+  // Disk write is opt-in
   if (!_enabled) return;
-  const line = JSON.stringify({ ts: new Date().toISOString(), ...event });
   const dest = telemetryPath();
   try {
     const dir = path.dirname(dest);
     if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
-    fs.appendFileSync(dest, line + '\n');
+    fs.appendFileSync(dest, JSON.stringify(entry) + '\n');
   } catch {
     // telemetry must never surface errors to the user
   }
 }
 
 /**
- * Wrap an async operation with timing. Emits a command_timing event on completion.
- * When telemetry is disabled, executes fn() with zero overhead.
+ * Wrap an async operation with timing. Emits a command_timing event.
+ * Zero overhead when telemetry is disabled and user hasn't opted in.
  */
 export async function timed<T>(
   meta: { command: string; transport: 'cli' | 'mcp'; mode?: string },
   fn: () => Promise<T>,
   getResultCount?: (result: T) => number,
 ): Promise<T> {
-  if (!_enabled) return fn();
   const t0 = Date.now();
   try {
     const result = await fn();
@@ -73,42 +132,116 @@ export async function timed<T>(
   }
 }
 
-/** Emit a version_snapshot once per session. Fetches qmd version via execFile. */
+// ── Snapshot emitters ─────────────────────────────────────────────────────────
+
+/**
+ * Capture version info once per session. Synchronous parts resolve immediately;
+ * qmd version is filled in async via execFile. Records to JSONL only if enabled.
+ */
 export function emitVersionSnapshot(binary: string, pluginVersion: string): void {
-  if (!_enabled || _versionSnapshotEmitted) return;
+  if (_versionSnapshotEmitted) return;
   _versionSnapshotEmitted = true;
+
+  // Capture synchronous parts now so the diagnostics report is always populated
+  _versionSnap = {
+    plugin_version: pluginVersion,
+    qmd_version: 'resolving…',
+    node_version: process.versions.node ?? 'unknown',
+    electron_version: process.versions.electron ?? 'unknown',
+    os_platform: os.platform(),
+    os_arch: os.arch(),
+    cpu_cores: os.cpus().length,
+  };
+
   execFile(binary, ['--version'], { timeout: 5000, env: buildEnv() }, (err, stdout) => {
-    record({
-      kind: 'version_snapshot',
-      plugin_version: pluginVersion,
-      qmd_version: err ? 'unknown' : stdout.trim(),
-      node_version: process.versions.node ?? 'unknown',
-      electron_version: process.versions.electron ?? 'unknown',
-      os_platform: os.platform(),
-      os_arch: os.arch(),
-      cpu_cores: os.cpus().length,
-    });
+    if (_versionSnap) _versionSnap.qmd_version = err ? 'unknown' : stdout.trim();
+    if (_enabled) record({ kind: 'version_snapshot', ..._versionSnap! });
   });
 }
 
-/** Emit an index_snapshot at most once per calendar day. */
+/** Record daily index stats. Caches for diagnostics regardless of _enabled. */
 export function maybeEmitIndexSnapshot(totalDocs: number, totalVectors: number, collectionCount: number): void {
+  _indexSnap = { total_docs: totalDocs, total_vectors: totalVectors, collection_count: collectionCount };
+
   if (!_enabled) return;
   const today = new Date().toISOString().slice(0, 10);
   if (_lastIndexSnapshotDate === today) return;
   _lastIndexSnapshotDate = today;
-  record({ kind: 'index_snapshot', total_docs: totalDocs, total_vectors: totalVectors, collection_count: collectionCount });
+  record({ kind: 'index_snapshot', ..._indexSnap });
 }
 
-/** Emit a hardware_snapshot once per session (GPU info comes from qmd status output). */
+/** Record hardware info once per session. Caches for diagnostics regardless of _enabled. */
 export function emitHardwareSnapshot(gpuInfo?: string, gpuVram?: string, gpuDevice?: string): void {
+  _hardwareSnap = {
+    cpu_cores: os.cpus().length,
+    ...(gpuInfo   ? { gpu_info:   gpuInfo   } : {}),
+    ...(gpuVram   ? { gpu_vram:   gpuVram   } : {}),
+    ...(gpuDevice ? { gpu_device: gpuDevice } : {}),
+  };
+
   if (!_enabled || _hardwareSnapshotEmitted) return;
   _hardwareSnapshotEmitted = true;
-  record({
-    kind: 'hardware_snapshot',
-    cpu_cores: os.cpus().length,
-    ...(gpuInfo  ? { gpu_info:   gpuInfo  } : {}),
-    ...(gpuVram  ? { gpu_vram:   gpuVram  } : {}),
-    ...(gpuDevice ? { gpu_device: gpuDevice } : {}),
+  record({ kind: 'hardware_snapshot', ..._hardwareSnap });
+}
+
+// ── Diagnostics report ────────────────────────────────────────────────────────
+
+/** Build a diagnostics report JSON string from cached state + recent ring events. */
+export function buildDiagnosticsReport(settings: DiagnosticsSettingsSnapshot): string {
+  return JSON.stringify(
+    {
+      generated: new Date().toISOString(),
+      plugin:   _versionSnap  ?? { note: 'not yet collected — open Settings once to populate' },
+      system:   _hardwareSnap ?? { note: 'not yet collected' },
+      index:    _indexSnap    ?? { note: 'not yet collected' },
+      settings: {
+        transport_mode:      settings.transportMode,
+        default_search_mode: settings.defaultSearchMode,
+        no_rerank:           settings.noRerank,
+        index_name:          settings.indexName || '(default)',
+        log_level:           settings.logLevel,
+        telemetry_enabled:   settings.telemetryEnabled,
+      },
+      recent_events: _ring.slice(-20).map((e) => ({ ...e })),
+    },
+    null,
+    2,
+  );
+}
+
+/**
+ * Post a report to paste.rs (anonymous, no auth).
+ * Returns the paste URL on success.
+ * Note: paste.rs URLs are not indexed but ARE publicly accessible to anyone with the link.
+ */
+export function postReport(content: string): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const data = Buffer.from(content, 'utf8');
+    const req = https.request(
+      {
+        hostname: 'paste.rs',
+        path: '/',
+        method: 'POST',
+        headers: {
+          'Content-Type': 'text/plain; charset=utf-8',
+          'Content-Length': data.byteLength,
+        },
+      },
+      (res) => {
+        const chunks: Buffer[] = [];
+        res.on('data', (c: Buffer) => chunks.push(c));
+        res.on('end', () => {
+          const body = Buffer.concat(chunks).toString('utf8').trim();
+          if (res.statusCode && res.statusCode >= 200 && res.statusCode < 300 && body.startsWith('http')) {
+            resolve(body);
+          } else {
+            reject(new Error(`paste.rs responded ${res.statusCode}: ${body.slice(0, 120)}`));
+          }
+        });
+      },
+    );
+    req.on('error', reject);
+    req.write(data);
+    req.end();
   });
 }

--- a/src/util/telemetry.ts
+++ b/src/util/telemetry.ts
@@ -1,0 +1,114 @@
+const fs = require('fs') as typeof import('fs');
+const os = require('os') as typeof import('os');
+const path = require('path') as typeof import('path');
+const { execFile } = require('child_process') as typeof import('child_process');
+
+import { buildEnv } from './env';
+
+export type TelemetryEvent =
+  | { kind: 'command_timing'; command: string; transport: 'cli' | 'mcp'; mode?: string; duration_ms: number; success: boolean; result_count?: number }
+  | { kind: 'version_snapshot'; plugin_version: string; qmd_version: string; node_version: string; electron_version: string; os_platform: string; os_arch: string; cpu_cores: number }
+  | { kind: 'index_snapshot'; total_docs: number; total_vectors: number; collection_count: number }
+  | { kind: 'hardware_snapshot'; cpu_cores: number; gpu_info?: string; gpu_vram?: string; gpu_device?: string };
+
+let _enabled = false;
+let _versionSnapshotEmitted = false;
+let _hardwareSnapshotEmitted = false;
+let _lastIndexSnapshotDate = '';
+
+export function setTelemetryEnabled(v: boolean): void {
+  _enabled = v;
+  // Reset per-session flags when re-enabled so a fresh session gets fresh snapshots
+  if (v) {
+    _versionSnapshotEmitted = false;
+    _hardwareSnapshotEmitted = false;
+  }
+}
+
+export function isTelemetryEnabled(): boolean {
+  return _enabled;
+}
+
+function telemetryPath(): string {
+  return path.join(os.homedir(), '.cache', 'qmd', 'telemetry.jsonl');
+}
+
+export function record(event: TelemetryEvent): void {
+  if (!_enabled) return;
+  const line = JSON.stringify({ ts: new Date().toISOString(), ...event });
+  const dest = telemetryPath();
+  try {
+    const dir = path.dirname(dest);
+    if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+    fs.appendFileSync(dest, line + '\n');
+  } catch {
+    // telemetry must never surface errors to the user
+  }
+}
+
+/**
+ * Wrap an async operation with timing. Emits a command_timing event on completion.
+ * When telemetry is disabled, executes fn() with zero overhead.
+ */
+export async function timed<T>(
+  meta: { command: string; transport: 'cli' | 'mcp'; mode?: string },
+  fn: () => Promise<T>,
+  getResultCount?: (result: T) => number,
+): Promise<T> {
+  if (!_enabled) return fn();
+  const t0 = Date.now();
+  try {
+    const result = await fn();
+    record({
+      kind: 'command_timing',
+      ...meta,
+      duration_ms: Date.now() - t0,
+      success: true,
+      ...(getResultCount !== undefined ? { result_count: getResultCount(result) } : {}),
+    });
+    return result;
+  } catch (err) {
+    record({ kind: 'command_timing', ...meta, duration_ms: Date.now() - t0, success: false });
+    throw err;
+  }
+}
+
+/** Emit a version_snapshot once per session. Fetches qmd version via execFile. */
+export function emitVersionSnapshot(binary: string, pluginVersion: string): void {
+  if (!_enabled || _versionSnapshotEmitted) return;
+  _versionSnapshotEmitted = true;
+  execFile(binary, ['--version'], { timeout: 5000, env: buildEnv() }, (err, stdout) => {
+    record({
+      kind: 'version_snapshot',
+      plugin_version: pluginVersion,
+      qmd_version: err ? 'unknown' : stdout.trim(),
+      node_version: process.versions.node ?? 'unknown',
+      electron_version: process.versions.electron ?? 'unknown',
+      os_platform: os.platform(),
+      os_arch: os.arch(),
+      cpu_cores: os.cpus().length,
+    });
+  });
+}
+
+/** Emit an index_snapshot at most once per calendar day. */
+export function maybeEmitIndexSnapshot(totalDocs: number, totalVectors: number, collectionCount: number): void {
+  if (!_enabled) return;
+  const today = new Date().toISOString().slice(0, 10);
+  if (_lastIndexSnapshotDate === today) return;
+  _lastIndexSnapshotDate = today;
+  record({ kind: 'index_snapshot', total_docs: totalDocs, total_vectors: totalVectors, collection_count: collectionCount });
+}
+
+/** Emit a hardware_snapshot once per session (GPU info comes from qmd status output). */
+export function emitHardwareSnapshot(gpuInfo?: string, gpuVram?: string, gpuDevice?: string): void {
+  if (!_enabled || _hardwareSnapshotEmitted) return;
+  _hardwareSnapshotEmitted = true;
+  record({
+    kind: 'hardware_snapshot',
+    cpu_cores: os.cpus().length,
+    ...(gpuInfo  ? { gpu_info:   gpuInfo  } : {}),
+    ...(gpuVram  ? { gpu_vram:   gpuVram  } : {}),
+    ...(gpuDevice ? { gpu_device: gpuDevice } : {}),
+  });
+}

--- a/styles.css
+++ b/styles.css
@@ -1321,3 +1321,41 @@
   text-align: right;
   color: var(--text-muted);
 }
+
+/* ── Diagnostics card ──────────────────────────────────────── */
+.qmd-diag-card {
+  border: 1px solid var(--background-modifier-border);
+  border-radius: 6px;
+  padding: 12px 14px;
+  margin: 6px 0 12px;
+}
+.qmd-diag-label {
+  font-size: 0.85em;
+  font-weight: 600;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin-bottom: 4px;
+}
+.qmd-diag-card .qmd-muted { font-size: 0.88em; margin: 0 0 10px; }
+.qmd-diag-btn-row { display: flex; gap: 8px; }
+.qmd-diag-btn {
+  padding: 4px 12px;
+  border-radius: 4px;
+  font-size: 0.88em;
+  cursor: pointer;
+}
+.qmd-diag-share-result { margin-top: 10px; font-size: 0.88em; }
+.qmd-diag-share-result--hidden { display: none; }
+.qmd-diag-url {
+  display: block;
+  word-break: break-all;
+  margin-bottom: 4px;
+  font-family: var(--font-monospace);
+  font-size: 0.9em;
+}
+.qmd-diag-privacy-warn {
+  color: var(--text-warning, var(--text-muted));
+  font-size: 0.85em;
+  margin: 4px 0 0;
+}


### PR DESCRIPTION
## Summary

Adds telemetry infrastructure for observing plugin behaviour. **Disabled by default** — no data is written or sent anywhere until the user opts in.

Closes #185.

## What's in this PR

### New: `src/util/telemetry.ts`
Self-contained module. No new npm dependencies.

- **`record(event)`** — writes a JSON line to `~/.cache/qmd/telemetry.jsonl` (only when enabled). Always pushes to in-memory ring buffer (100 events, for diagnostics).
- **`timed(meta, fn, getCount?)`** — wraps any async call with timing, emits `command_timing` event.
- **`emitVersionSnapshot(binary, pluginVersion)`** — once per session: plugin/qmd/node/electron versions + OS/CPU info.
- **`maybeEmitIndexSnapshot(docs, vectors, count)`** — at most once per calendar day: index headcounts.
- **`emitHardwareSnapshot(gpuInfo?, gpuVram?, gpuDevice?)`** — once per session from `qmd status` output.
- **`buildDiagnosticsReport(settings)`** — compiles version + system + index + settings + last 20 ring events into formatted JSON. Works even when telemetry is disabled.
- **`postReport(content)`** — POSTs to `paste.rs` (anonymous, no auth), returns URL.

### Settings (`src/settings.ts`)

New **Usage analytics** toggle in General settings (default off).

New **Diagnostics report** card (always visible):
- 📋 **Copy** — writes JSON report to clipboard.
- 📤 **Share…** — posts to paste.rs, shows URL inline with explicit "not private" warning.

### Instrumentation

| Command | Where |
|---------|-------|
| `search`/`vsearch`/`query` (CLI) | `CliQmdClient.search()` via `timed()` |
| `query` (MCP) | `McpQmdClient.search()` via `timed()` |
| `update` (reindex) | `main.ts reindex()` |
| `embed` | `main.ts embed()` |
| Index/hardware snapshots | `main.ts refreshStatusBar()` |

### CI

Build job now uploads `main.js` + `manifest.json` + `styles.css` as a downloadable artifact (7-day retention) — available from the Actions tab for test installs without waiting for a release.

## Test plan

- [ ] With toggle **off** (default): confirm `~/.cache/qmd/telemetry.jsonl` is never created; diagnostics Copy/Share still work
- [ ] Enable toggle: run a search, confirm a `command_timing` line appears in the JSONL
- [ ] Check Share button: posts report, shows URL with privacy warning, URL opens in browser
- [ ] Restart Obsidian with toggle on: confirm `version_snapshot` and `index_snapshot` appear in JSONL
- [ ] Type-check: `npx tsc --noEmit` passes
- [ ] Download the CI artifact from the Actions tab and install in a test vault

## Notes on delivery (future work)

- `paste.rs` = anonymous paste, URL is unguessable but not private. Disclosure in README + privacy policy needed before community plugin submission.
- OpenTelemetry SDK is explicitly prohibited by Obsidian Developer Policies (client-side telemetry libraries banned). Our approach (local JSONL + optional paste share) stays within policy.
- GitHub secret gists require auth since May 2021. `paste.rs` is the closest equivalent without a token.