### PR TITLE
fix(ci): restore missing version in actions/checkout@v6 for deploy-docs

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -24,7 +24,7 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v
+      - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
         with:
           node-version: 24


### PR DESCRIPTION
Line 27 of `deploy-docs.yml` had `actions/checkout@v` (version suffix stripped, likely a bad edit). This caused every release-triggered docs deploy to fail immediately with "unable to find version `v`".

Fixes docs deploys for all releases since 0.12.10.