### PR TITLE
chore: auto-close milestone on release, document workflow conventions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,3 +49,23 @@ jobs:
           GIT_AUTHOR_EMAIL: github-actions[bot]@users.noreply.github.com
           GIT_COMMITTER_NAME: github-actions[bot]
           GIT_COMMITTER_EMAIL: github-actions[bot]@users.noreply.github.com
+
+      # Close the matching vX.Y.Z milestone if one exists.
+      # manifest.json is updated in-place by semantic-release when a release
+      # is cut, so its version reflects the just-published tag.
+      # If no release was cut this run, the version won't match any open
+      # milestone and the step is a silent no-op.
+      - name: Close milestone
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          VERSION=$(node -p "require('./manifest.json').version")
+          MILESTONE=$(gh api repos/${{ github.repository }}/milestones \
+            --jq ".[] | select(.title == \"v${VERSION}\") | .number" 2>/dev/null)
+          if [ -n "$MILESTONE" ]; then
+            echo "Closing milestone v${VERSION} (#${MILESTONE})"
+            gh api repos/${{ github.repository }}/milestones/${MILESTONE} \
+              -X PATCH -f state=closed
+          else
+            echo "No open milestone found for v${VERSION} — skipping"
+          fi

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -162,3 +162,26 @@ npm rebuild -g better-sqlite3
 nvm use <version-used-to-install-qmd>
 npm install -g @tobilu/qmd
 ```
+
+---
+
+## Workflow conventions
+
+### Commit messages — reference issue numbers
+
+Always append `(#N)` to commit messages when a commit addresses a tracked issue. This makes the issue number a clickable hyperlink in GitHub Release notes (semantic-release passes commit messages through verbatim):
+
+```
+fix: strip @@ diff-hunk prefix from search result snippets (#194)
+feat: default to semantic mode, add power-mode toggle (#193)
+```
+
+Without the `(#N)` suffix the fix lands in the release but has no visible link back to the issue.
+
+### Issue → PR → release flow
+
+1. Assign issue → create branch `fix/N-short-description` or `feat/N-short-description`
+2. Open PR as **draft** immediately; add `Closes #N` to the PR body
+3. Test locally with `VAULT_PATH=~/path/to/vault npm run deploy` before marking ready
+4. Merge → semantic-release cuts a version → issues auto-close → milestone auto-closes if all issues resolved
+5. Regressions get a **new issue**, not a reopened one


### PR DESCRIPTION
## Summary

- **Milestone auto-close**: adds a `Close milestone` step to `release.yml` that reads the version from `manifest.json` after semantic-release runs and closes the matching `vX.Y.Z` milestone. Silent no-op if no release was cut or no open milestone matches.
- **Workflow conventions in CLAUDE.md**: documents the `(#N)` commit message convention (makes issue numbers hyperlinks in release notes) and the issue → branch → draft PR → local test → merge → release → auto-close flow.

## Test plan

- [ ] CI passes
- [ ] After merge, next release that cuts a version should close the matching milestone (v1.0.0 when all MVP issues land)
- [ ] Runs where no release is cut should log "No open milestone found — skipping"

## Related

- Closes #199 (successComment verification tracking — that check happens after next issue-closing release)

🤖 Generated with [Claude Code](https://claude.com/claude-code)