### PR TITLE
fix: Docs link opens in browser at versioned URL; strip @@ snippet prefix

### DIFF
--- a/docs-site/src/pages/docs/[version].astro
+++ b/docs-site/src/pages/docs/[version].astro
@@ -1,0 +1,26 @@
+---
+// Versioned docs route: /docs/<version>
+// All versions currently redirect to /docs (same content for every release).
+// When version-specific docs are needed, add conditional content here
+// keyed on `version` from Astro.params.
+import versionsJson from '../../../../versions.json';
+
+export function getStaticPaths() {
+  return Object.keys(versionsJson).map((version) => ({ params: { version } }));
+}
+
+const { version } = Astro.params;
+const base = import.meta.env.BASE_URL;
+const docsUrl = `${base}/docs`;
+---
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta http-equiv="refresh" content={`0; url=${docsUrl}`} />
+  <title>QMD Search {version} · Docs</title>
+</head>
+<body>
+  <p>Redirecting to <a href={docsUrl}>current docs</a>…</p>
+</body>
+</html>

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -26,7 +26,7 @@ export function normalizeResult(raw: RawQmdResult): QmdResult {
     docid: raw.docid,
     score: raw.score,
     title: raw.title ?? '',
-    snippet: raw.snippet ?? '',
+    snippet: (raw.snippet ?? '').replace(/^@@[^@]*@@\s*/, ''),
     line: raw.line,
     collection: uriMatch ? uriMatch[1] : '',
     path: uriMatch ? uriMatch[2] : raw.file,

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -82,7 +82,9 @@ export class QmdSettingTab extends PluginSettingTab {
     const docsLink = headerMeta.createEl('a', { cls: 'qmd-docs-link', text: 'Docs ↗' });
     docsLink.addEventListener('click', (e) => {
       e.preventDefault();
-      window.open('https://stevenwolfe.github.io/obsidian-qmd-search/', '_blank');
+      const version = this.plugin.manifest.version;
+      const { shell } = require('electron') as typeof import('electron');
+      void shell.openExternal(`https://stevenwolfe.github.io/obsidian-qmd-search/docs/${version}`);
     });
     headerMeta.createSpan({ text: ' · ' });
     const binaryPill = headerMeta.createSpan({ cls: 'qmd-binary-pill qmd-binary-pill--checking', text: 'checking…' });


### PR DESCRIPTION
## What

Two small bug fixes from 0.14.0 testing feedback.

### #109 — Docs link does nothing on click

`window.open()` is blocked in Obsidian's Electron renderer — calls to it silently no-op. Replaced with `shell.openExternal()`, which correctly hands the URL off to the system browser.

The URL now includes the installed plugin version:
```
https://stevenwolfe.github.io/obsidian-qmd-search/docs/0.14.0
```

### Versioned docs routes (forward-compatible)

Added `docs/[version].astro` to the docs site. `getStaticPaths()` reads `versions.json` and generates a redirect page for every released version → `/docs`. All 40 existing versions get a redirect page; new versions are included automatically at each release build.

When version-specific docs are needed later, the URL pattern and route are already in place — swap the redirect for real content.

### #194 — `@@ -1,3 @@` prefix in search result snippets

`qmd --json` includes diff-hunk context markers in the `snippet` field. Stripped in `normalizeResult()` before any downstream rendering:
```ts
snippet: (raw.snippet ?? '').replace(/^@@[^@]*@@\s*/, ''),
```

## Test plan

- [x] CI passes
- [ ] Deploy to vault: Docs ↗ link in settings opens the browser at the correct versioned URL
- [x] Search results no longer show `@@ ... @@` prefix text
- [ ] Docs site builds (46 pages including all versioned routes)
- [ ] `/docs/0.14.0` redirects to `/docs` in browser

Closes #109
Closes #194