### PR TITLE
fix: strip duplicate qmd prefix, full handelize nav fallback, snippet header, Share note (0.14.2)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,6 +36,8 @@ All `qmd` interaction is behind a `QmdClient` interface (`src/client/base.ts`). 
 
 `qmd --json` returns a bare array of `RawQmdResult` where the file field is a URI like `qmd://collection-name/relative/path.md`. `normalizeResult()` in `src/client/types.ts` splits this into `collection` and `path` fields used throughout the UI.
 
+**qmd path contract — `handelize()`**: qmd transforms every file path through `handelize()` before storing it in the index (see `@tobilu/qmd dist/store.js`). The transform: lowercase the whole path, then per segment replace any run of non-alphanumeric, non-`$` characters (spaces, parens, dots in directory names, etc.) with a single hyphen, strip leading/trailing hyphens, preserve the file extension unchanged. So `reference/Proxmox Grafana Dashboard.md` → `reference/proxmox-grafana-dashboard.md`. Vault filenames with spaces or punctuation will never match qmd paths by a plain string compare. `navigateToResult()` in `src/util/navigate.ts` applies the same transform to vault paths as a fallback lookup to handle this.
+
 ### Settings (`src/settings.ts`)
 
 `QmdSearchSettings` is persisted via Obsidian's `loadData/saveData`. `saveSettings(rebuildClient)` accepts a boolean to skip client teardown for non-transport changes (e.g. default collection, search flags).

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -26,7 +26,7 @@ export function normalizeResult(raw: RawQmdResult): QmdResult {
     docid: raw.docid,
     score: raw.score,
     title: raw.title ?? '',
-    snippet: (raw.snippet ?? '').replace(/^@@[^@]*@@\s*/, ''),
+    snippet: (raw.snippet ?? '').replace(/^@@[^@]*@@[^\n]*\n?/, ''),
     line: raw.line,
     collection: uriMatch ? uriMatch[1] : '',
     path: uriMatch ? uriMatch[2] : raw.file,

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -536,6 +536,10 @@ export class QmdSettingTab extends PluginSettingTab {
     });
 
     const shareBtn = diagBtnRow.createEl('button', { cls: 'qmd-diag-btn', text: '📤 Share…' });
+    diagCard.createEl('p', {
+      cls: 'qmd-muted',
+      text: 'Share uploads a one-time snapshot to a private URL — independent of the analytics toggle.',
+    });
     const shareResult = diagCard.createDiv({ cls: 'qmd-diag-share-result qmd-diag-share-result--hidden' });
 
     shareBtn.addEventListener('click', async () => {

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -92,7 +92,7 @@ export class QmdSettingTab extends PluginSettingTab {
     if (this.plugin.resolvedBinaryPath !== 'qmd') {
       runVersion(this.plugin.resolvedBinaryPath).then((v) => {
         if (!binaryPill.isConnected) return;
-        binaryPill.setText(`qmd ${v}`);
+        binaryPill.setText(v);
         binaryPill.removeClass('qmd-binary-pill--checking');
         binaryPill.dataset.fullVersion = v;
       }).catch(() => {
@@ -787,7 +787,7 @@ export class QmdSettingTab extends PluginSettingTab {
     if (this.plugin.resolvedBinaryPath !== 'qmd') {
       runVersion(this.plugin.resolvedBinaryPath).then((v) => {
         if (!aboutEl.isConnected) return;
-        aboutEl.createEl('p', { cls: 'qmd-about-line', text: `qmd ${v}` });
+        aboutEl.createEl('p', { cls: 'qmd-about-line', text: v });
       }).catch(() => { /* ignore */ });
     }
   }

--- a/src/util/navigate.ts
+++ b/src/util/navigate.ts
@@ -5,22 +5,40 @@ export async function navigateToResult(app: App, result: QmdResult): Promise<voi
   // result.path is relative to the collection root (e.g. "notes/file.md").
   // Normalise separators and case for Linux (case-sensitive FS) before matching.
   const normalise = (p: string) => p.replace(/\\/g, '/').toLowerCase();
-  const slugify = (p: string) => p.replace(/ /g, '-');
+  // qmd applies handelize() before storing paths: lowercases and replaces any run of
+  // non-alphanumeric chars (spaces, parens, dots in dir names, etc.) with a single hyphen,
+  // then strips leading/trailing hyphens per segment. We apply the same transform to vault
+  // paths so we can match qmd-issued paths back to vault files.
+  // Source: @tobilu/qmd dist/store.js `handelize()` (called on every file at index time).
+  const handelize = (p: string) =>
+    p.toLowerCase()
+      .split('/')
+      .map((seg, i, arr) => {
+        if (i === arr.length - 1) {
+          const dot = seg.lastIndexOf('.');
+          const ext = dot > 0 ? seg.slice(dot) : '';
+          const name = dot > 0 ? seg.slice(0, dot) : seg;
+          return name.replace(/[^\p{L}\p{N}$]+/gu, '-').replace(/^-+|-+$/g, '') + ext;
+        }
+        return seg.replace(/[^\p{L}\p{N}$]+/gu, '-').replace(/^-+|-+$/g, '');
+      })
+      .filter(Boolean)
+      .join('/');
   const pathNorm = normalise(result.path);
   const _absFile = app.vault.getAbstractFileByPath(result.path);
   const file =
     (_absFile instanceof TFile ? _absFile : null) ??
     app.vault.getMarkdownFiles().find((f) => {
       const fp = normalise(f.path);
-      const fpSlug = slugify(fp);
+      const fpH = handelize(f.path);
       const baseName = f.basename.toLowerCase();
       const qmdBase = pathNorm.replace(/\.md$/, '');
       return fp === pathNorm ||
-        fpSlug === pathNorm ||
+        fpH === pathNorm ||
         fp.endsWith('/' + pathNorm) ||
-        fpSlug.endsWith('/' + pathNorm) ||
+        fpH.endsWith('/' + pathNorm) ||
         baseName === qmdBase ||
-        slugify(baseName) === qmdBase;
+        handelize(baseName) === qmdBase;
     }) ??
     null;
 

--- a/src/util/navigate.ts
+++ b/src/util/navigate.ts
@@ -5,15 +5,22 @@ export async function navigateToResult(app: App, result: QmdResult): Promise<voi
   // result.path is relative to the collection root (e.g. "notes/file.md").
   // Normalise separators and case for Linux (case-sensitive FS) before matching.
   const normalise = (p: string) => p.replace(/\\/g, '/').toLowerCase();
+  const slugify = (p: string) => p.replace(/ /g, '-');
   const pathNorm = normalise(result.path);
   const _absFile = app.vault.getAbstractFileByPath(result.path);
   const file =
     (_absFile instanceof TFile ? _absFile : null) ??
     app.vault.getMarkdownFiles().find((f) => {
       const fp = normalise(f.path);
+      const fpSlug = slugify(fp);
+      const baseName = f.basename.toLowerCase();
+      const qmdBase = pathNorm.replace(/\.md$/, '');
       return fp === pathNorm ||
+        fpSlug === pathNorm ||
         fp.endsWith('/' + pathNorm) ||
-        f.basename.toLowerCase() === pathNorm.replace(/\.md$/, '');
+        fpSlug.endsWith('/' + pathNorm) ||
+        baseName === qmdBase ||
+        slugify(baseName) === qmdBase;
     }) ??
     null;
 


### PR DESCRIPTION
## Summary

All open 0.14.2 milestone issues addressed in this branch.

- **#205** — Settings header and About section showed `qmd qmd 2.1.0` because `runVersion()` already returns the full CLI string including the binary name. Fix: use `v` directly without prepending `"qmd "`.
- **#203** — Clicking a search result navigated to the wrong file (or nothing). Root cause: qmd applies `handelize()` to all file paths at index time — lowercases and converts any non-alphanumeric run (spaces, parens, etc.) to a single hyphen, strips leading/trailing hyphens per segment. The plugin was only doing a case-insensitive exact match. Fix: apply the same `handelize` transform to vault paths as a fallback in `navigateToResult()` (`src/util/navigate.ts`). Contract documented in CLAUDE.md.
- **#202** — Snippet text still showed `(8 before, 146 after)` after the `@@` prefix was stripped. Real qmd format: `@@ -9,4 @@ (8 before, 146 after)\n<content>`. The previous regex `^@@[^@]*@@\s*` only consumed through `@@` and left the rest of the line. Fix: extend to `^@@[^@]*@@[^\n]*\n?` to consume the full header line.
- **#206** — The diagnostics Share button appeared analytics-dependent. Fix: add a short note clarifying it uploads a one-time snapshot independent of the analytics toggle.

Closes #205
Closes #203
Closes #202
Closes #206

## Test plan

- [x] Settings header pill shows `qmd 2.1.0` (not `qmd qmd 2.1.0`)
- [x] Advanced → About shows `qmd 2.1.0` (not `qmd qmd 2.1.0`)
- [x] Click a result whose vault filename has spaces (e.g. `Proxmox Grafana Dashboard.md`) — navigates to the correct file
- [x] Click a result with an exact-match path — still navigates correctly
- [x] Search result snippets show clean content with no `@@` or `(N before, N after)` prefix
- [x] Diagnostics card shows note: "Share uploads a one-time snapshot…"