### PR TITLE
fix: clarify registered vs unregistered state in collection panel (#99)

### DIFF
--- a/src/settings.ts
+++ b/src/settings.ts
@@ -133,8 +133,11 @@ export class QmdSettingTab extends PluginSettingTab {
     this.plugin.client.status().then((status) => {
       if (!contentArea.isConnected) return;
 
-      const vaultPath = (this.app.vault.adapter as { basePath?: string }).basePath ?? '';
-      const matched = status.collections.find((c) => c.path === vaultPath);
+      const normPath = (p: string) => p.replace(/\/+$/, '');
+      const vaultPath = normPath((this.app.vault.adapter as { basePath?: string }).basePath ?? '');
+      const matched = status.collections.find(
+        (c) => c.path !== undefined && normPath(c.path) === vaultPath,
+      );
 
       // Build into a detached element then swap atomically — avoids blank-flash during refresh
       const renderTarget = document.createElement('div') as HTMLElement;
@@ -218,6 +221,10 @@ export class QmdSettingTab extends PluginSettingTab {
             (err) => (err ? reject(new Error(err.message)) : resolve()),
           );
         });
+        indexBtn.textContent = 'Indexing…';
+        new Notice(`QMD: indexing files for "${name}"…`);
+        await this.plugin.reindex();
+        indexBtn.textContent = 'Embedding…';
         new Notice(`QMD: generating embeddings for "${name}"…`);
         await this.plugin.embed();
         new Notice(`QMD: vault registered as "${name}" ✓`);
@@ -261,8 +268,16 @@ export class QmdSettingTab extends PluginSettingTab {
         cls: 'qmd-health-warn-sub',
         text: 'Hybrid & semantic modes will fall back to keyword until you run this.',
       });
+    } else if (matched) {
+      cardHeader.createEl('strong', { text: matched.name });
+      cardHeader.createSpan({ cls: 'qmd-col-badge', text: 'indexed' });
+      if (matched.lastIndexed) {
+        const timeEl = cardHeader.createEl('span', { cls: 'qmd-health-meta' });
+        timeEl.dataset.lastIndexed = matched.lastIndexed;
+        timeEl.setText(`Last indexed ${timeAgo(matched.lastIndexed)}`);
+      }
     } else {
-      cardHeader.createEl('strong', { text: 'Index healthy' });
+      cardHeader.createEl('strong', { text: 'Other collections indexed' });
       if (lastIndexed) {
         const timeEl = cardHeader.createEl('span', { cls: 'qmd-health-meta' });
         timeEl.dataset.lastIndexed = lastIndexed;
@@ -307,13 +322,14 @@ export class QmdSettingTab extends PluginSettingTab {
       });
     }
 
-    // Stats row
+    // Stats row — show vault-specific doc count when matched, global totals otherwise
     const statsRow = card.createDiv({ cls: 'qmd-health-stats' });
+    const displayDocs = matched ? matched.docCount : totalDocs;
     const embeddingsStr = isPartial
-      ? `0 / ${totalDocs.toLocaleString()}`
+      ? `0 / ${displayDocs.toLocaleString()}`
       : `${totalVectors.toLocaleString()} / ${totalDocs.toLocaleString()}`;
     const statItems: Array<[string, string, boolean?]> = [
-      ['Documents', totalDocs.toLocaleString()],
+      ['Documents', displayDocs.toLocaleString()],
       ['Collections', String(status.collections.length)],
       ['Embeddings', embeddingsStr, isPartial],
     ];


### PR DESCRIPTION
Closes #99

## What changed

### Bug fixes
- **Path normalization**: vault path comparison now trims trailing slashes before matching, fixing the case where `qmd collection show` returns a path with a trailing `/` that `basePath` doesn't have — caused the vault to appear unregistered after a successful registration or fresh install
- **Registration flow**: `reindex()` (`qmd update`) is now run between `collection add` and `embed()`. Without it, `qmd embed` was called against an empty text index — embeddings would fail silently or produce nothing

### UX / state clarity
- Health card header when vault IS registered: shows `{collection name}` + `indexed` badge instead of the ambiguous `"Index healthy"` — immediately answers "is my vault indexed?"
- Health card header when vault is NOT registered (but other collections exist): shows `"Other collections indexed"` instead of `"Index healthy"`, which was the source of the confusion (#99 scenario 3)
- Stats row `Documents` count now shows the matched vault's own `docCount` rather than the global total across all collections

## Testing notes from #99

From the issue comments:
> "In second / test vault -- using 'Index this vault' appeared successful, but UI did not update to show the now-existing collection. Further attempts to (re)Index this vault failed."

The root causes:
1. Path comparison failed (trailing slash mismatch) → vault not detected as `matched` → showed registration card again → user could only "register" which tried `collection add` again and failed
2. Even when registration did succeed, embeddings step ran against an empty index

Both are fixed here.

## Known limitation (follow-up needed)

The `+ Add other vault` / `+ Add collection` button in the Collections section header uses the current vault's path for all cases. Adding a different vault directory requires the CLI (`qmd collection add <path> --name <name>`). This is separate from #99 and would need a path-input field added to `CollectionNameModal`.

## Test plan
- [ ] Fresh vault with no qmd collections: shows "Index your vault to start searching" card
- [ ] Click "Index this vault": button steps through Registering → Indexing → Embedding, then UI refreshes to show health card with vault name + "indexed" badge
- [ ] Vault already registered in qmd before plugin install: health card shows vault name + "indexed" immediately on settings open
- [ ] Second vault with other collections already registered: shows "This vault is not registered" card + "Other collections indexed" health card (not "Index healthy")