### PR TITLE
fix: semantic default, prewarm alignment, cold-start hint (#209)

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -100,12 +100,11 @@ export default class QmdSearchPlugin extends Plugin {
     if (this.modelLoaded) return;
     log.debug('pre-warming qmd models…');
     try {
-      // Dummy hybrid search triggers expansion, embedding, and reranker models
+      // Semantic warms the embedding model (~300 MB); avoids loading the full 3 GB reranking stack
       await this.client.search({
         query: '_warmup_',
-        mode: 'hybrid',
+        mode: 'semantic',
         limit: 1,
-        noRerank: false,
       });
       this.modelLoaded = true;
       log.debug('qmd models warmed up ✓');

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -42,7 +42,7 @@ export const DEFAULT_SETTINGS: QmdSearchSettings = {
   transportMode: 'cli',
   mcpPort: 8181,
   defaultCollection: '',
-  defaultSearchMode: 'hybrid',
+  defaultSearchMode: 'semantic',
   noRerank: false,
   candidateLimit: undefined,
   minScore: undefined,
@@ -434,8 +434,8 @@ export class QmdSettingTab extends PluginSettingTab {
       .setDesc(isPartial ? 'Hybrid and Semantic require embeddings. Currently coerced to Keyword.' : '')
       .addDropdown((dd) => {
         dd.addOption('keyword', 'Keyword')
-          .addOption('semantic', 'Semantic')
-          .addOption('hybrid', 'Hybrid (default)')
+          .addOption('semantic', 'Semantic (default)')
+          .addOption('hybrid', 'Hybrid — AI reranking (~2.5 GB extra models)')
           .setValue(this.plugin.settings.defaultSearchMode)
           .onChange(async (value) => {
             this.plugin.settings.defaultSearchMode = value as 'keyword' | 'semantic' | 'hybrid';

--- a/src/ui/SearchModal.ts
+++ b/src/ui/SearchModal.ts
@@ -91,7 +91,7 @@ export class SearchModal extends Modal {
     const MODE_TOOLTIPS: Record<string, string> = {
       keyword:  'BM25 keyword search — fast, no embeddings needed',
       semantic: 'Vector similarity search — requires embeddings',
-      hybrid:   'BM25 + vectors + AI reranking — best quality, requires embeddings',
+      hybrid:   'BM25 + vectors + AI reranking — best quality, requires embeddings (~2.5 GB extra models)',
     };
     for (const [label, value] of [
       ['Keyword', 'keyword'],
@@ -172,10 +172,10 @@ export class SearchModal extends Modal {
 
     this.queryInput.focus();
 
-    // Pre-warm qmd on first open so the user's first real search doesn't cold-start
+    // Warm the text index on first open — keyword only, does not set modelLoaded
+    // (modelLoaded tracks embedding model readiness; keyword prewarm doesn't load it)
     if (!this.plugin.modelLoaded) {
       void this.client.search({ query: '_warmup_', mode: 'keyword', limit: 1 })
-        .then(() => { this.plugin.modelLoaded = true; })
         .catch(() => { /* ignore — warmup failure is non-fatal */ });
     }
   }


### PR DESCRIPTION
Closes #209

## Changes

**`defaultSearchMode`: `hybrid` → `semantic`**
Semantic uses the embedding model only (~300 MB, already present after first index). Hybrid triggers the full reranking stack (~3 GB additional models). Fresh installs on hybrid were silently cold-starting a 3 GB download on the first query. Existing users with a saved `hybrid` value are unaffected — persisted settings win over defaults.

**Hybrid cost label**
Settings dropdown: `"Hybrid — AI reranking (~2.5 GB extra models)"`. SearchModal toolbar tooltip updated to match. Users who select hybrid are now informed of the download cost before committing.

**`prewarm()` mode: `hybrid` → `semantic`**
The launch prewarm (MCP mode) was loading the full reranking stack unnecessarily. Changed to `semantic` — warms the embedding model, which is the bottleneck for the new default mode.

**`modelLoaded` semantics fixed**
The modal-open keyword prewarm was setting `plugin.modelLoaded = true` after completing. `modelLoaded` tracks whether the embedding model is warm; a keyword search does not load it. This was suppressing the 1.5 s cold-start hint (`"Starting up… (first search may take a moment)"`) for all subsequent embedding searches. Removed the premature set — `modelLoaded` is now only set by `prewarm()` (semantic) and by successful real searches.

## Test plan
- [ ] Fresh install: default mode is Semantic in both settings dropdown and modal toolbar
- [ ] Existing install with saved `hybrid`: still opens in Hybrid (persisted value respected)
- [ ] Hybrid tooltip in modal shows `~2.5 GB extra models`
- [ ] Settings dropdown hybrid option shows cost note
- [ ] First semantic search after cold start shows 1.5 s "Starting up…" hint (no longer suppressed by keyword prewarm)
- [ ] First semantic search after prewarm (MCP mode, 30 s after Obsidian load) is fast