### PR TITLE
fix: ship.yml PR body syntax error

### DIFF
--- a/.github/workflows/ship.yml
+++ b/.github/workflows/ship.yml
@@ -145,11 +145,10 @@ jobs:
         run: |
           VERSION="${{ steps.version.outputs.next }}"
           BRANCH="${{ steps.version.outputs.branch }}"
+          PR_BODY="Automated release PR for v${VERSION}."$'\n\n'"CI (type-check, lint, build) passed on \`main\` before this branch was cut. The branch contains only version-file changes (\`manifest.json\`, \`versions.json\`)."
           PR_URL=$(gh pr create \
             --title "chore(release): $VERSION" \
-            --body "Automated release PR for v${VERSION}.
-
-CI (type-check, lint, build) passed on \`main\` before this branch was cut. The branch contains only version-file changes (\`manifest.json\`, \`versions.json\`)." \
+            --body "$PR_BODY" \
             --base main \
             --head "$BRANCH")
           PR_NUMBER=$(echo "$PR_URL" | grep -oE '[0-9]+$')


### PR DESCRIPTION
Fixes the multi-line string literal in the `gh pr create --body` argument (line 152). The blank line inside a double-quoted string inside a `run: |` block causes a shell parse error. Moved the body into a variable using `$'\n\n'` for the blank line.