### PR TITLE
fix: dispatch deploy-docs after release in ship.yml

### DIFF
--- a/.github/workflows/ship.yml
+++ b/.github/workflows/ship.yml
@@ -228,3 +228,12 @@ jobs:
           else
             echo "No open milestone found for v${VERSION} — skipping"
           fi
+
+      # ── Deploy docs ────────────────────────────────────────────────────────
+      # GITHUB_TOKEN-created releases don't fire the `release: published` event
+      # (GitHub loop prevention), so deploy-docs.yml never auto-triggers.
+      # Dispatch it explicitly instead — deploy-docs.yml has workflow_dispatch.
+      - name: Deploy docs
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh workflow run deploy-docs.yml --ref main


### PR DESCRIPTION
GITHUB_TOKEN-created releases don't fire the `release: published` event (GitHub loop prevention), so `deploy-docs.yml` never triggers automatically after `ship.yml` publishes a release. Fix: add an explicit `gh workflow run deploy-docs.yml` dispatch step at the end of `ship.yml`. Since `deploy-docs.yml` already has `workflow_dispatch` as a trigger, this works with `GITHUB_TOKEN` — no PAT needed.