### PR TITLE
fix: add actions: write permission for deploy-docs dispatch

### DIFF
--- a/.github/workflows/ship.yml
+++ b/.github/workflows/ship.yml
@@ -30,6 +30,7 @@ jobs:
       pull-requests: write
       statuses: write
       issues: write
+      actions: write
 
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
The `gh workflow run` call in the Deploy docs step requires `actions: write` permission. Without it, the API returns HTTP 403. Adds the missing permission to the ship job.