### PR TITLE
ci: pin actions to SHAs, add secret scan and license check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,8 +12,8 @@ jobs:
     name: Type check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6
         with:
           node-version: 24
           cache: npm
@@ -24,8 +24,8 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6
         with:
           node-version: 24
           cache: npm
@@ -39,8 +39,8 @@ jobs:
     # block PR merges; they surface high-severity prod-dep vulnerabilities for
     # awareness. Dev deps are excluded (--omit=dev) to reduce noise.
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6
         with:
           node-version: 24
           cache: npm
@@ -51,15 +51,15 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6
         with:
           node-version: 24
           cache: npm
       - run: npm ci
       - run: npm run build
       - name: Upload plugin artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
         with:
           name: obsidian-qmd-search
           path: |
@@ -67,3 +67,35 @@ jobs:
             manifest.json
             styles.css
           retention-days: 7
+
+  gitleaks:
+    name: Secret scan
+    runs-on: ubuntu-latest
+    # Advisory — does not block merges. Surfaces accidentally committed secrets
+    # for awareness; complement to GitHub secret scanning (which alerts post-push).
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+        with:
+          fetch-depth: 0
+      - uses: gitleaks/gitleaks-action@ff98106e4c7b2bc287b24eaf42907196329070c7  # v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  license:
+    name: License check
+    runs-on: ubuntu-latest
+    # Verifies production runtime deps stay within permissive licenses before
+    # community plugin submission. Dev deps (--production flag) are excluded.
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6
+        with:
+          node-version: 24
+          cache: npm
+      - run: npm ci
+      - run: >
+          npx license-checker
+          --onlyAllow 'MIT;ISC;BSD-2-Clause;BSD-3-Clause;Apache-2.0;CC0-1.0;Unlicense;Python-2.0;CC-BY-3.0;CC-BY-4.0;0BSD;BlueOak-1.0.0'
+          --excludePrivatePackages
+          --production

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -24,8 +24,8 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6
         with:
           node-version: 24
           cache: npm
@@ -36,7 +36,7 @@ jobs:
       - name: Build
         run: npm run build
         working-directory: docs-site
-      - uses: actions/upload-pages-artifact@v5
+      - uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9  # v5
         with:
           path: docs-site/dist
 
@@ -50,4 +50,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v5
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128  # v5

--- a/.github/workflows/ship.yml
+++ b/.github/workflows/ship.yml
@@ -33,11 +33,11 @@ jobs:
       actions: write
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6
         with:
           node-version: 24
           cache: npm


### PR DESCRIPTION
Closes #172
Closes #173
Closes #174

## Changes

### #173 — Pin all GitHub Actions to commit SHAs
All three workflow files (`ci.yml`, `deploy-docs.yml`, `ship.yml`) now reference actions by their commit SHA with the tag in a comment. Mutable tags can be silently swapped by a compromised upstream.

| Action | Tag | SHA |
|--------|-----|-----|
| actions/checkout | v6 | `de0fac2e` |
| actions/setup-node | v6 | `48b55a01` |
| actions/upload-artifact | v4 | `ea165f8d` |
| actions/upload-pages-artifact | v5 | `fc324d35` |
| actions/deploy-pages | v5 | `cd2ce8fc` |
| gitleaks/gitleaks-action | v2 | `ff98106e` |

### #172 — Gitleaks secret scan
New `Secret scan` job in `ci.yml`. Uses `gitleaks/gitleaks-action@v2` with `fetch-depth: 0` (full history scan). Marked `continue-on-error: true` — advisory, not a blocking required check. Complements GitHub secret scanning which only alerts post-push.

### #174 — License compliance check
New `License check` job in `ci.yml`. Runs `license-checker --production` against the permissive-license allowlist. Only checks runtime dependencies (dev deps excluded via `--production`). Production deps are currently MIT + Python-2.0 (js-yaml), both permitted.

## Notes

- `Secret scan` and `License check` are not added to the `main-protection` required status checks — both are advisory.
- SHA pins should be updated via Renovate or manually when new major versions release.