### PR TITLE
fix(ci): restore missing version in actions/checkout@v6 for deploy-docs

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -24,7 +24,7 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v
+      - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
         with:
           node-version: 24


### PR DESCRIPTION
## Summary

<!-- 1-3 bullets: what changed and why -->

## Type

- [ ] feat — new behaviour
- [ ] fix — bug fix
- [ ] chore — tooling / deps / release
- [ ] docs — documentation only
- [ ] ci — CI/CD changes

## Test plan

<!-- Bulleted checklist of how to verify this works -->
- [ ] 

## Checklist

- [ ] `npx tsc --noEmit` passes
- [ ] `npm run build` produces a clean `main.js`
- [ ] Tested in Obsidian with a real vault (or: docs/CI-only change, no runtime impact)
- [ ] CHANGELOG.md updated (for feat/fix)
